### PR TITLE
implement tests to prevent SynchronizationContext deadlocks (issue#17)

### DIFF
--- a/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
+++ b/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
@@ -494,6 +494,95 @@ namespace ConfigCat.Client.Tests
             Assert.AreEqual(1, myMock.DisposeCount);
         }
 
+        [TestMethod]
+        public void ForceRefresh_ShouldInvokeConfigServiceRefreshConfigAsync()
+        {
+            // Arrange
+
+            configServiceMock.Setup(m => m.RefreshConfigAsync()).Returns(Task.CompletedTask);
+
+            IConfigCatClient instance = new ConfigCatClient(
+                configServiceMock.Object,
+                loggerMock.Object,
+                evaluatorMock.Object,
+                configDeserializerMock.Object);
+
+            // Act
+
+            instance.ForceRefresh();
+
+            // Assert
+
+            configServiceMock.Verify(m => m.RefreshConfigAsync(), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task ForceRefreshAsync_ShouldInvokeConfigServiceRefreshConfigAsync()
+        {
+            // Arrange
+
+            configServiceMock.Setup(m => m.RefreshConfigAsync()).Returns(Task.CompletedTask);
+
+            IConfigCatClient instance = new ConfigCatClient(
+                configServiceMock.Object,
+                loggerMock.Object,
+                evaluatorMock.Object,
+                configDeserializerMock.Object);
+
+            // Act
+
+            await instance.ForceRefreshAsync();
+
+            // Assert
+
+            configServiceMock.Verify(m => m.RefreshConfigAsync(), Times.Once);
+        }
+
+
+        [TestMethod]
+        public void ForceRefresh_ConfigServiceThrowException_ShouldNotReThrowTheExceptionAndLogsError()
+        {
+            // Arrange
+
+            configServiceMock.Setup(m => m.RefreshConfigAsync()).Throws<Exception>();
+
+            IConfigCatClient instance = new ConfigCatClient(
+                configServiceMock.Object,
+                loggerMock.Object,
+                evaluatorMock.Object,
+                configDeserializerMock.Object);
+
+            // Act
+
+            instance.ForceRefresh();
+
+            // Assert
+
+            loggerMock.Verify(m => m.Error(It.IsAny<string>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task ForceRefreshAsync_ConfigServiceThrowException_ShouldNotReThrowTheExceptionAndLogsError()
+        {
+            // Arrange
+
+            configServiceMock.Setup(m => m.RefreshConfigAsync()).Throws<Exception>();
+
+            IConfigCatClient instance = new ConfigCatClient(
+                configServiceMock.Object,
+                loggerMock.Object,
+                evaluatorMock.Object,
+                configDeserializerMock.Object);
+
+            // Act
+
+            await instance.ForceRefreshAsync();            
+
+            // Assert
+
+            loggerMock.Verify(m => m.Error(It.IsAny<string>()), Times.Once);
+        }
+
         internal class FakeConfigService : ConfigServiceBase, IConfigService
         {
             public byte DisposeCount { get; private set; }

--- a/src/ConfigCat.Client.Tests/SynchronizationContextDeadlockTests.cs
+++ b/src/ConfigCat.Client.Tests/SynchronizationContextDeadlockTests.cs
@@ -1,0 +1,114 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Threading;
+using Moq;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace ConfigCat.Client.Tests
+{
+    [TestClass]
+    public class SynchronizationContextDeadlockTests
+    {
+        private const string SDKKEY = "PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A";
+
+        private readonly Mock<SynchronizationContext> syncContextMock;
+
+        private static SynchronizationContext synchronizationContextBackup;
+
+        public SynchronizationContextDeadlockTests()
+        {
+            synchronizationContextBackup = SynchronizationContext.Current;
+
+            syncContextMock = new Mock<SynchronizationContext>
+            {
+                CallBase = true
+            };
+
+            SynchronizationContext.SetSynchronizationContext(syncContextMock.Object);
+        }
+
+        [ClassCleanup]
+        public static void ClassCleanup()
+        {
+            SynchronizationContext.SetSynchronizationContext(synchronizationContextBackup);
+        }
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            syncContextMock.Reset();
+        }
+
+        [TestMethod]
+        public void AutoPollDeadLockCheck()
+        {
+            var client = new ConfigCatClient(new AutoPollConfiguration
+            {
+                SdkKey = SDKKEY,
+                Logger = new ConsoleLogger(LogLevel.Off)                
+            });
+
+            ClientDeadlockCheck(client);
+        }
+
+        [TestMethod]
+        public void ManualPollDeadLockCheck()
+        {
+            var client = new ConfigCatClient(new ManualPollConfiguration
+            {
+                SdkKey = SDKKEY,
+                Logger = new ConsoleLogger(LogLevel.Off)
+            });
+
+            ClientDeadlockCheck(client);
+        }
+
+        [TestMethod]
+        public void LazyLoadDeadLockCheck()
+        {
+            var client = new ConfigCatClient(new LazyLoadConfiguration
+            {
+                SdkKey = SDKKEY,
+                Logger = new ConsoleLogger(LogLevel.Off)
+            });
+
+            ClientDeadlockCheck(client);
+        }
+
+        private void ClientDeadlockCheck(IConfigCatClient client)
+        {
+            var methods = typeof(IConfigCatClient).GetMethods().Where(x => !x.IsSpecialName).OrderBy(o => o.Name);
+
+            foreach (var m in methods)
+            {
+                var parameters = Enumerable.Repeat<object>(null, m.GetParameters().Length).ToArray();
+
+                MethodInfo mi = m;
+
+                if (m.IsGenericMethod)
+                {
+                    mi = m.MakeGenericMethod(typeof(string));
+                }
+
+                Console.WriteLine($"Invoke '{mi.Name}' method");
+
+                if (mi.ReturnType.IsSubclassOf(typeof(Task)))
+                {
+                    var task = (Task)mi.Invoke(client, parameters);
+
+                    task.ConfigureAwait(false);
+                    task.Wait();
+                }
+                else
+                {
+                    mi.Invoke(client, parameters);
+                }
+
+                syncContextMock.Verify(x => x.Post(It.IsAny<SendOrPostCallback>(), It.IsAny<object>()), Times.Never, $"Method: {mi.Name}");
+                syncContextMock.Verify(x => x.Send(It.IsAny<SendOrPostCallback>(), It.IsAny<object>()), Times.Never, $"Method: {mi.Name}");
+            }
+        }
+    }
+}

--- a/src/ConfigCatClient/ConfigService/AutoPollConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/AutoPollConfigService.cs
@@ -67,7 +67,7 @@ namespace ConfigCat.Client.ConfigService
             {
                 if (!initializedEventSlim.Wait(delay))
                 {
-                    await RefreshLogicAsync("init");
+                    await RefreshLogicAsync("init").ConfigureAwait(false);
                 }
 
                 cacheConfig = await this.configCache.GetAsync(base.cacheKey).ConfigureAwait(false);
@@ -78,7 +78,7 @@ namespace ConfigCat.Client.ConfigService
 
         public async Task RefreshConfigAsync()
         {
-            await RefreshLogicAsync("manual");
+            await RefreshLogicAsync("manual").ConfigureAwait(false);
         }
 
         private async Task RefreshLogicAsync(object sender)

--- a/src/ConfigCatClient/HttpConfigFetcher.cs
+++ b/src/ConfigCatClient/HttpConfigFetcher.cs
@@ -45,7 +45,7 @@ namespace ConfigCat.Client
 
             try
             {
-                var fetchResult = await FetchRequest(lastConfig, this.requestUri);
+                var fetchResult = await FetchRequest(lastConfig, this.requestUri).ConfigureAwait(false);
 
                 var response = fetchResult.Item1;
 


### PR DESCRIPTION
implement tests to prevent synchronize context deadlocks. 
closes #17 