### PR TITLE
Set java home to jdk11 for sonarcloud

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,9 @@ dotnet_csproj:
   assembly_version: '{version}'
   file_version: '{version}'
   informational_version: '{version}'
+install:
+- set JAVA_HOME=C:\Program Files\Java\jdk11
+- set PATH=%JAVA_HOME%\bin;%PATH%
 build_script: 
  - cmd: echo __BUILD__
  - msbuild /verbosity:normal /t:Restore src/ConfigCatClient.sln


### PR DESCRIPTION
### Describe the purpose of your pull request

Sonarcloud scans are failing due to a wrong java version, so this PR points the JAVA_HOME env variable to jdk11.

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read contributing guidelines.
