### PR TITLE
Ensure internal serializer doesn't use the global json serializer settings

### DIFF
--- a/src/ConfigCat.Client.Tests/ConfigEvaluatorTestsBase.cs
+++ b/src/ConfigCat.Client.Tests/ConfigEvaluatorTestsBase.cs
@@ -1,5 +1,6 @@
 ﻿using ConfigCat.Client.Evaluate;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -23,7 +24,7 @@ namespace ConfigCat.Client.Tests
 
         public ConfigEvaluatorTestsBase()
         {
-            this.configEvaluator = new RolloutEvaluator(logger, new ConfigDeserializer(logger));
+            this.configEvaluator = new RolloutEvaluator(logger, new ConfigDeserializer(logger, JsonSerializer.Create()));
 
             this.config = new ProjectConfig(this.GetSampleJson(), DateTime.UtcNow, null);
         }

--- a/src/ConfigCat.Client.Tests/DataGovernanceTests.cs
+++ b/src/ConfigCat.Client.Tests/DataGovernanceTests.cs
@@ -63,6 +63,7 @@ namespace ConfigCat.Client.Tests
                 "DEMO",
                 Mock.Of<ILogger>(),
                 handlerMock.Object,
+                JsonSerializer.Create(),
                 configuration.IsCustomBaseUrl);
 
             // Act
@@ -378,6 +379,7 @@ namespace ConfigCat.Client.Tests
                 "DEMO",
                 Mock.Of<ILogger>(),
                 handlerMock.Object,
+                JsonSerializer.Create(),
                 fetchConfig.IsCustomBaseUrl);
 
             // Act

--- a/src/ConfigCat.Client.Tests/DeserializerTests.cs
+++ b/src/ConfigCat.Client.Tests/DeserializerTests.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System;
+using System.IO;
+
+namespace ConfigCat.Client.Tests
+{
+    [TestClass]
+    public class DeserializerTests
+    {
+        [TestMethod]
+        public void Ensure_Global_Settings_Doesnt_Interfere()
+        {
+            JsonConvert.DefaultSettings = () =>
+            {
+                var settings = new JsonSerializerSettings();
+                settings.Converters.Add(new StringEnumConverter { AllowIntegerValues = false });
+                return settings;
+            };
+
+            var deserializer = new ConfigDeserializer(new LoggerWrapper(new ConsoleLogger(LogLevel.Debug)), JsonSerializer.Create());
+
+            deserializer.TryDeserialize(new ProjectConfig("{\"p\": {\"u\": \"http://example.com\", \"r\": 0}}", DateTime.Now, ""), out var configs);
+
+            JsonConvert.DefaultSettings = null;
+        }
+    }
+}

--- a/src/ConfigCat.Client.Tests/DeserializerTests.cs
+++ b/src/ConfigCat.Client.Tests/DeserializerTests.cs
@@ -22,8 +22,6 @@ namespace ConfigCat.Client.Tests
             var deserializer = new ConfigDeserializer(new LoggerWrapper(new ConsoleLogger(LogLevel.Debug)), JsonSerializer.Create());
 
             deserializer.TryDeserialize(new ProjectConfig("{\"p\": {\"u\": \"http://example.com\", \"r\": 0}}", DateTime.Now, ""), out var configs);
-
-            JsonConvert.DefaultSettings = null;
         }
     }
 }

--- a/src/ConfigCat.Client.Tests/HttpConfigFetcherTests.cs
+++ b/src/ConfigCat.Client.Tests/HttpConfigFetcherTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 using System;
 using System.Net;
 using System.Threading.Tasks;
@@ -15,7 +16,7 @@ namespace ConfigCat.Client.Tests
 
             var myHandler = new MyFakeHttpClientHandler();
 
-            var instance = new HttpConfigFetcher(new Uri("http://example.com"), "1.0", new MyCounterLogger(), myHandler, false);
+            var instance = new HttpConfigFetcher(new Uri("http://example.com"), "1.0", new MyCounterLogger(), myHandler, JsonSerializer.Create(), false);
 
             // Act
 
@@ -33,7 +34,7 @@ namespace ConfigCat.Client.Tests
 
             var myHandler = new MyFakeHttpClientHandler();
 
-            var instance = new HttpConfigFetcher(new Uri("http://example.com"), "1.0", new MyCounterLogger(), myHandler, false);
+            var instance = new HttpConfigFetcher(new Uri("http://example.com"), "1.0", new MyCounterLogger(), myHandler, JsonSerializer.Create(), false);
 
             // Act
 
@@ -51,7 +52,7 @@ namespace ConfigCat.Client.Tests
 
             var myHandler = new MyFakeHttpClientHandler(HttpStatusCode.Forbidden);
 
-            var instance = new HttpConfigFetcher(new Uri("http://example.com"), "1.0", new MyCounterLogger(), myHandler, false);
+            var instance = new HttpConfigFetcher(new Uri("http://example.com"), "1.0", new MyCounterLogger(), myHandler, JsonSerializer.Create(), false);
 
             var lastConfig = new ProjectConfig("{ }", DateTime.UtcNow, "\"ETAG\"");
 
@@ -71,7 +72,7 @@ namespace ConfigCat.Client.Tests
 
             var myHandler = new ExceptionThrowerHttpClientHandler(new WebException());
 
-            var instance = new HttpConfigFetcher(new Uri("http://example.com"), "1.0", new MyCounterLogger(), myHandler, false);
+            var instance = new HttpConfigFetcher(new Uri("http://example.com"), "1.0", new MyCounterLogger(), myHandler, JsonSerializer.Create(), false);
 
             var lastConfig = new ProjectConfig("{ }", DateTime.UtcNow, "\"ETAG\"");
 


### PR DESCRIPTION
### Describe the purpose of your pull request

Users can unintentionally give bad settings to the SDK through json.NET's `JsonConvert.DefaultSettings` static property.
This PR changes the serializer handling towards a single serializer instance rather than the static `JsonConvert` methods. They always use the `DefaultSettings`, even when you override their settings parameter.

### Related issues (only if applicable)

n/a

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
