### PR TITLE
Reduce JSON deserialization calls, add benchmarks

### DIFF
--- a/benchmarks/ConfigCatClient.Benchmarks.csproj
+++ b/benchmarks/ConfigCatClient.Benchmarks.csproj
@@ -1,0 +1,34 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Configurations>Debug;Release;Benchmark</Configurations>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Benchmark|AnyCPU'">
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="ConfigCat.Client" Version="6.1.20" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="ConfigCat.Client.Benchmark">
+      <HintPath>..\src\ConfigCatClient\bin\Benchmark\netstandard2.1\ConfigCat.Client.Benchmark.dll</HintPath>
+      <Aliases>from_project</Aliases>
+      <Private>true</Private>
+    </Reference>
+  </ItemGroup>
+
+  <Target Name="ChangeAliasOfNugetReferencedStashbox" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">
+    <ItemGroup>
+      <ReferencePath Condition="'%(FileName)' == 'ConfigCat.Client'">
+        <Aliases>from_nuget</Aliases>
+      </ReferencePath>
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/benchmarks/ConfigCatClient.Benchmarks.sln
+++ b/benchmarks/ConfigCatClient.Benchmarks.sln
@@ -1,0 +1,39 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30907.101
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConfigCatClient.Benchmarks", "ConfigCatClient.Benchmarks.csproj", "{B7381881-0709-4F72-AE6C-3778979CD8C1}"
+	ProjectSection(ProjectDependencies) = postProject
+		{B51439A6-F230-46E5-9BC3-7E4E9FA841FC} = {B51439A6-F230-46E5-9BC3-7E4E9FA841FC}
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConfigCatClient", "..\src\ConfigCatClient\ConfigCatClient.csproj", "{B51439A6-F230-46E5-9BC3-7E4E9FA841FC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Benchmark|Any CPU = Benchmark|Any CPU
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B7381881-0709-4F72-AE6C-3778979CD8C1}.Benchmark|Any CPU.ActiveCfg = Benchmark|Any CPU
+		{B7381881-0709-4F72-AE6C-3778979CD8C1}.Benchmark|Any CPU.Build.0 = Benchmark|Any CPU
+		{B7381881-0709-4F72-AE6C-3778979CD8C1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B7381881-0709-4F72-AE6C-3778979CD8C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B7381881-0709-4F72-AE6C-3778979CD8C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B7381881-0709-4F72-AE6C-3778979CD8C1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B51439A6-F230-46E5-9BC3-7E4E9FA841FC}.Benchmark|Any CPU.ActiveCfg = Benchmark|Any CPU
+		{B51439A6-F230-46E5-9BC3-7E4E9FA841FC}.Benchmark|Any CPU.Build.0 = Benchmark|Any CPU
+		{B51439A6-F230-46E5-9BC3-7E4E9FA841FC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B51439A6-F230-46E5-9BC3-7E4E9FA841FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B51439A6-F230-46E5-9BC3-7E4E9FA841FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B51439A6-F230-46E5-9BC3-7E4E9FA841FC}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {71FC06CD-80AD-4090-863E-1965313C9027}
+	EndGlobalSection
+EndGlobal

--- a/benchmarks/GetValueBenchmarks.cs
+++ b/benchmarks/GetValueBenchmarks.cs
@@ -1,0 +1,45 @@
+﻿extern alias from_nuget;
+extern alias from_project;
+using BenchmarkDotNet.Attributes;
+using System;
+
+namespace ConfigCatClient.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class GetValueBenchmarks
+    {
+        private readonly from_project::ConfigCat.Client.IConfigCatClient newClient = from_project::ConfigCat.Client.ConfigCatClientBuilder
+            .Initialize("rv3YCMKenkaM7xkOCVQfeg/-I_w49WSQUWdZypPPM4Yyg")
+            .WithManualPoll()
+            .WithBaseUrl(new Uri("https://test-cdn-global.configcat.com"))
+            .Create();
+
+        private readonly from_nuget::ConfigCat.Client.IConfigCatClient oldClient = from_nuget::ConfigCat.Client.ConfigCatClientBuilder
+            .Initialize("rv3YCMKenkaM7xkOCVQfeg/-I_w49WSQUWdZypPPM4Yyg")
+            .WithManualPoll()
+            .WithBaseUrl(new Uri("https://test-cdn-global.configcat.com"))
+            .Create();
+
+        private from_project::ConfigCat.Client.User newUser = new from_project::ConfigCat.Client.User("test@test.com");
+        private from_nuget::ConfigCat.Client.User oldUser = new from_nuget::ConfigCat.Client.User("test@test.com");
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            this.oldClient.ForceRefresh();
+            this.newClient.ForceRefresh();
+        }
+
+        [Benchmark(Baseline = true)]
+        public object OldGetValue()
+        {
+            return this.oldClient.GetValue("asd", false, oldUser);
+        }
+
+        [Benchmark]
+        public object NewGetValue()
+        {
+            return this.newClient.GetValue("asd", false, newUser);
+        }
+    }
+}

--- a/benchmarks/Program.cs
+++ b/benchmarks/Program.cs
@@ -1,0 +1,15 @@
+﻿using BenchmarkDotNet.Running;
+using System;
+
+namespace ConfigCatClient.Benchmarks
+{
+    class Program
+    {
+        private static void Main(string[] args)
+        {
+            BenchmarkRunner.Run<GetValueBenchmarks>();
+
+            Console.ReadKey();
+        }
+    }
+}

--- a/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
+++ b/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
@@ -282,9 +282,9 @@ namespace ConfigCat.Client.Tests
             // Arrange
 
             configServiceMock.Setup(m => m.GetConfigAsync()).ReturnsAsync(ProjectConfig.Empty);
-            IDictionary<string, Setting> o = new Dictionary<string, Setting>();
+            var o = new SettingsWithPreferences();
             configDeserializerMock
-                .Setup(m => m.TryDeserialize(It.IsAny<ProjectConfig>(), out o))
+                .Setup(m => m.TryDeserialize(It.IsAny<string>(), out o))
                 .Throws<Exception>();
 
             IConfigCatClient instance = new ConfigCatClient(
@@ -310,9 +310,9 @@ namespace ConfigCat.Client.Tests
             // Arrange
 
             configServiceMock.Setup(m => m.GetConfigAsync()).ReturnsAsync(ProjectConfig.Empty);
-            IDictionary<string, Setting> o = new Dictionary<string, Setting>();
+            var o = new SettingsWithPreferences();
             configDeserializerMock
-                .Setup(m => m.TryDeserialize(It.IsAny<ProjectConfig>(), out o))
+                .Setup(m => m.TryDeserialize(It.IsAny<string>(), out o))
                 .Returns(false);
 
             IConfigCatClient instance = new ConfigCatClient(
@@ -382,9 +382,9 @@ namespace ConfigCat.Client.Tests
             // Arrange
 
             configServiceMock.Setup(m => m.GetConfigAsync()).ReturnsAsync(ProjectConfig.Empty);
-            IDictionary<string, Setting> o = new Dictionary<string, Setting>();
+            var o = new SettingsWithPreferences();
             configDeserializerMock
-                .Setup(m => m.TryDeserialize(It.IsAny<ProjectConfig>(), out o))
+                .Setup(m => m.TryDeserialize(It.IsAny<string>(), out o))
                 .Returns(false);
 
             IConfigCatClient instance = new ConfigCatClient(
@@ -410,9 +410,9 @@ namespace ConfigCat.Client.Tests
             // Arrange
 
             configServiceMock.Setup(m => m.GetConfigAsync()).ReturnsAsync(ProjectConfig.Empty);
-            IDictionary<string, Setting> o = new Dictionary<string, Setting>();
+            var o = new SettingsWithPreferences();
             configDeserializerMock
-                .Setup(m => m.TryDeserialize(It.IsAny<ProjectConfig>(), out o))
+                .Setup(m => m.TryDeserialize(It.IsAny<string>(), out o))
                 .Returns(false);
 
             IConfigCatClient instance = new ConfigCatClient(

--- a/src/ConfigCat.Client.Tests/DataGovernanceTests.cs
+++ b/src/ConfigCat.Client.Tests/DataGovernanceTests.cs
@@ -63,7 +63,7 @@ namespace ConfigCat.Client.Tests
                 "DEMO",
                 Mock.Of<ILogger>(),
                 handlerMock.Object,
-                JsonSerializer.Create(),
+                Mock.Of<IConfigDeserializer>(),
                 configuration.IsCustomBaseUrl);
 
             // Act
@@ -379,7 +379,7 @@ namespace ConfigCat.Client.Tests
                 "DEMO",
                 Mock.Of<ILogger>(),
                 handlerMock.Object,
-                JsonSerializer.Create(),
+                new ConfigDeserializer(Mock.Of<ILogger>(), JsonSerializer.Create()),
                 fetchConfig.IsCustomBaseUrl);
 
             // Act

--- a/src/ConfigCat.Client.Tests/DeserializerTests.cs
+++ b/src/ConfigCat.Client.Tests/DeserializerTests.cs
@@ -21,7 +21,7 @@ namespace ConfigCat.Client.Tests
 
             var deserializer = new ConfigDeserializer(new LoggerWrapper(new ConsoleLogger(LogLevel.Debug)), JsonSerializer.Create());
 
-            deserializer.TryDeserialize(new ProjectConfig("{\"p\": {\"u\": \"http://example.com\", \"r\": 0}}", DateTime.Now, ""), out var configs);
+            deserializer.TryDeserialize("{\"p\": {\"u\": \"http://example.com\", \"r\": 0}}", out var configs);
         }
     }
 }

--- a/src/ConfigCat.Client.Tests/HttpConfigFetcherTests.cs
+++ b/src/ConfigCat.Client.Tests/HttpConfigFetcherTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 using Newtonsoft.Json;
 using System;
 using System.Net;
@@ -16,7 +17,7 @@ namespace ConfigCat.Client.Tests
 
             var myHandler = new MyFakeHttpClientHandler();
 
-            var instance = new HttpConfigFetcher(new Uri("http://example.com"), "1.0", new MyCounterLogger(), myHandler, JsonSerializer.Create(), false);
+            var instance = new HttpConfigFetcher(new Uri("http://example.com"), "1.0", new MyCounterLogger(), myHandler, Mock.Of<IConfigDeserializer>(), false);
 
             // Act
 
@@ -34,7 +35,7 @@ namespace ConfigCat.Client.Tests
 
             var myHandler = new MyFakeHttpClientHandler();
 
-            var instance = new HttpConfigFetcher(new Uri("http://example.com"), "1.0", new MyCounterLogger(), myHandler, JsonSerializer.Create(), false);
+            var instance = new HttpConfigFetcher(new Uri("http://example.com"), "1.0", new MyCounterLogger(), myHandler, Mock.Of<IConfigDeserializer>(), false);
 
             // Act
 
@@ -52,7 +53,7 @@ namespace ConfigCat.Client.Tests
 
             var myHandler = new MyFakeHttpClientHandler(HttpStatusCode.Forbidden);
 
-            var instance = new HttpConfigFetcher(new Uri("http://example.com"), "1.0", new MyCounterLogger(), myHandler, JsonSerializer.Create(), false);
+            var instance = new HttpConfigFetcher(new Uri("http://example.com"), "1.0", new MyCounterLogger(), myHandler, Mock.Of<IConfigDeserializer>(), false);
 
             var lastConfig = new ProjectConfig("{ }", DateTime.UtcNow, "\"ETAG\"");
 
@@ -72,7 +73,7 @@ namespace ConfigCat.Client.Tests
 
             var myHandler = new ExceptionThrowerHttpClientHandler(new WebException());
 
-            var instance = new HttpConfigFetcher(new Uri("http://example.com"), "1.0", new MyCounterLogger(), myHandler, JsonSerializer.Create(), false);
+            var instance = new HttpConfigFetcher(new Uri("http://example.com"), "1.0", new MyCounterLogger(), myHandler, Mock.Of<IConfigDeserializer>(), false);
 
             var lastConfig = new ProjectConfig("{ }", DateTime.UtcNow, "\"ETAG\"");
 

--- a/src/ConfigCatClient.sln
+++ b/src/ConfigCatClient.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2026
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30907.101
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConfigCatClient", "ConfigCatClient\ConfigCatClient.csproj", "{3046A17C-28AC-49A7-8B7B-E618FB5992F0}"
 EndProject

--- a/src/ConfigCatClient/ConfigCatClient.csproj
+++ b/src/ConfigCatClient/ConfigCatClient.csproj
@@ -81,12 +81,20 @@ Works with .NET, .NET Core, .NET Standard</Description>
           <NeutralLanguage></NeutralLanguage>
           <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\ConfigCatClient.xml</DocumentationFile>
           <DebugType>portable</DebugType>
+          <Configurations>Debug;Release;Benchmark</Configurations>
      </PropertyGroup>
 
      <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
           <Reference Include="System" />
           <Reference Include="Microsoft.CSharp" />
      </ItemGroup>
+
+    <PropertyGroup Condition="'$(Configuration)' == 'Benchmark'">
+        <AssemblyName>ConfigCat.Client.Benchmark</AssemblyName>
+        <AssemblyTitle>ConfigCat.Client.Benchmark</AssemblyTitle>
+        <RootNamespace>ConfigCat.Client.Benchmark</RootNamespace>
+        <Optimize>true</Optimize>
+    </PropertyGroup>
 
      <ItemGroup>
           <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/src/ConfigCatClient/Evaluate/RolloutEvaluator.cs
+++ b/src/ConfigCatClient/Evaluate/RolloutEvaluator.cs
@@ -47,13 +47,14 @@ namespace ConfigCat.Client.Evaluate
 
         private EvaluateResult EvaluateLogic(ProjectConfig projectConfig, string key, string logDefaultValue, string logDefaultVariationId, User user = null)
         {
-            if (!this.configDeserializer.TryDeserialize(projectConfig, out var settings))
+            if (!this.configDeserializer.TryDeserialize(projectConfig.JsonString, out var deserialized))
             {
                 this.log.Warning("Config deserialization failed, returning defaultValue");
 
                 return null;
             }
 
+            var settings = deserialized.Settings;
             if (!settings.TryGetValue(key, out var setting))
             {
                 var keys = string.Join(",", settings.Keys.Select(s => $"'{s}'").ToArray());

--- a/src/ConfigCatClient/IConfigDeserializer.cs
+++ b/src/ConfigCatClient/IConfigDeserializer.cs
@@ -5,6 +5,6 @@ namespace ConfigCat.Client
 {
     internal interface IConfigDeserializer
     {
-        bool TryDeserialize(ProjectConfig projectConfig, out IDictionary<string, Setting> settings);
+        bool TryDeserialize(string config, out SettingsWithPreferences settings);
     }
 }


### PR DESCRIPTION
### Describe the purpose of your pull request

Reducing the number of JSON deserialization calls by caching the last deserialized object in memory. Now, the deserialization is called only when the retrieved JSON string differs from the latest cached one.

Performance benchmark:
```
|      Method |       Mean |     Error |    StdDev | Ratio |  Gen 0 |  Gen 1 | Allocated |
|------------ |-----------:|----------:|----------:|------:|-------:|-------:|----------:|
| OldGetValue | 109.117 us | 0.2605 us | 0.2436 us |  1.00 | 2.9297 | 0.1221 |     25 KB |
| NewGetValue |   7.404 us | 0.0256 us | 0.0214 us |  0.07 | 0.9308 |      - |      8 KB |
```

### Related issues (only if applicable)

#22 

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
