### PR TITLE
Handle files locked by another process

### DIFF
--- a/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
+++ b/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
@@ -27,6 +27,8 @@ namespace ConfigCat.Client.Tests
             loggerMock.Reset();
             evaluatorMock.Reset();
             configDeserializerMock.Reset();
+
+            loggerMock.Setup(l => l.LogLevel).Returns(LogLevel.Warning);
         }
 
         [ExpectedException(typeof(ArgumentException))]

--- a/src/ConfigCat.Client.Tests/ConfigEvaluatorTestsBase.cs
+++ b/src/ConfigCat.Client.Tests/ConfigEvaluatorTestsBase.cs
@@ -11,7 +11,7 @@ namespace ConfigCat.Client.Tests
 {
     public abstract class ConfigEvaluatorTestsBase
     {
-        private readonly ILogger logger = new LoggerWrapper(new ConsoleLogger(LogLevel.Debug));
+        private readonly ILogger logger = new ConsoleLogger(LogLevel.Debug);
 
         private protected readonly IDictionary<string, Setting> config;
 
@@ -23,7 +23,7 @@ namespace ConfigCat.Client.Tests
 
         public ConfigEvaluatorTestsBase()
         {
-            this.configEvaluator = new RolloutEvaluator(logger);
+            this.configEvaluator = new RolloutEvaluator(new LoggerWrapper(logger));
 
             this.config = this.GetSampleJson().Deserialize<SettingsWithPreferences>().Settings;
         }

--- a/src/ConfigCatClient/ConfigCatClient.cs
+++ b/src/ConfigCatClient/ConfigCatClient.cs
@@ -121,7 +121,7 @@ namespace ConfigCat.Client
 
             configuration.Validate();
 
-            this.log = configuration.Logger;
+            this.log = new LoggerWrapper(configuration.Logger);
             this.configDeserializer = new ConfigDeserializer();
             this.configEvaluator = new RolloutEvaluator(this.log);
 
@@ -151,12 +151,12 @@ namespace ConfigCat.Client
         }
 
         /// <summary>
-        /// For test purpose only
+        /// For testing purposes only
         /// </summary>        
         internal ConfigCatClient(IConfigService configService, ILogger logger, IRolloutEvaluator evaluator, IConfigDeserializer configDeserializer)
         {
             this.configService = configService;
-            this.log = logger;
+            this.log = new LoggerWrapper(logger);
             this.configEvaluator = evaluator;
             this.configDeserializer = configDeserializer;
         }

--- a/src/ConfigCatClient/Configuration/ConfigurationBase.cs
+++ b/src/ConfigCatClient/Configuration/ConfigurationBase.cs
@@ -9,7 +9,7 @@ namespace ConfigCat.Client
     /// </summary>
     public abstract class ConfigurationBase
     {
-        private ILogger logger = LoggerWrapper.Default;
+        private ILogger logger = new ConsoleLogger(LogLevel.Warning);
 
         /// <summary>
         /// Logger instance.
@@ -19,7 +19,7 @@ namespace ConfigCat.Client
             get => this.logger;
             set
             {
-                this.logger = new LoggerWrapper(value ?? throw new ArgumentNullException(nameof(Logger)));
+                this.logger = value ?? throw new ArgumentNullException(nameof(Logger));
             }
         }
 

--- a/src/ConfigCatClient/Logging/LoggerWrapper.cs
+++ b/src/ConfigCatClient/Logging/LoggerWrapper.cs
@@ -4,15 +4,16 @@ namespace ConfigCat.Client
 {
     internal sealed class LoggerWrapper : ILogger
     {
-        public static readonly LoggerWrapper Default = new(new ConsoleLogger());
-
         private readonly ILogger logger;
 
-        public LogLevel LogLevel { get; set; }
+        public LogLevel LogLevel
+        {
+            get => logger.LogLevel;
+            set => logger.LogLevel = value;
+        }
 
         internal LoggerWrapper(ILogger logger)
         {
-            this.LogLevel = logger.LogLevel;
             this.logger = logger;
         }
 


### PR DESCRIPTION
### Describe the purpose of your pull request

In this PR I fixed a file locking issue with `FileSystemWatcher`. The watcher doesn't really care about whether the write is finished or not on a file that is changed, so our current reload function could easily fail on trying to open a locked file.
A lock-check loop was introduced to give the reload functionality more chance to open the file if it's being unlocked within 10s of trying.

I also made some consolidation around the `LogLevel`, it was kinda confusing as it was defined on both the `LoggerWrapper` and `ConsoleLogger` at the same time but it was just used on the `LoggerWrapper` really. Now the wrapper is only proxying the underlying ILogger's `LogLevel`.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
