### PR TITLE
Replace file system watcher with polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 6.5.0
+- Replace `FileSystemWatcher` with file polling in local file override data source.
+
+### 6.4.12
+- Fix various local file override data source issues.
+
 ### 6.4.9
 - Move the PollingMode option to public scope.
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,6 +1,6 @@
 # Steps to Deploy
 1. Run tests
-2. Set version in `appveyor.yml` (e.g: from `version: 2.5.{build}` to `version: 2.6.{build}`)
+2. Set version in `appveyor.yml` (e.g: from `build_version: 6.5.0` to `build_version: 6.5.1`)
 3. Update release notes in ConfigCatClient.csproj (PackageReleaseNotes)
 4. Push to `master`
 5. Deploy to NuGet.org

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,6 @@
-version: 6.4.{build}
+environment:
+  build_version: 6.5.0
+version: $(build_version)-{build}
 image: Visual Studio 2022
 configuration: Release
 skip_commits:
@@ -8,11 +10,11 @@ skip_commits:
 dotnet_csproj:
   patch: true
   file: '**\*.csproj'
-  version: '{version}'
-  package_version: '{version}'
-  assembly_version: '{version}'
-  file_version: '{version}'
-  informational_version: '{version}'
+  version: '{build_version}'
+  package_version: '{build_version}'
+  assembly_version: '{build_version}'
+  file_version: '{build_version}'
+  informational_version: '{build_version}'
 install:
 - cmd: dotnet tool install -g InheritDocTool
 build_script: 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,11 +10,11 @@ skip_commits:
 dotnet_csproj:
   patch: true
   file: '**\*.csproj'
-  version: '{build_version}'
-  package_version: '{build_version}'
-  assembly_version: '{build_version}'
-  file_version: '{build_version}'
-  informational_version: '{build_version}'
+  version: $(build_version)
+  package_version: $(build_version)
+  assembly_version: $(build_version)
+  file_version: $(build_version)
+  informational_version: $(build_version)
 install:
 - cmd: dotnet tool install -g InheritDocTool
 build_script: 

--- a/src/ConfigCat.Client.Tests/OverrideTests.cs
+++ b/src/ConfigCat.Client.Tests/OverrideTests.cs
@@ -121,7 +121,7 @@ namespace ConfigCat.Client.Tests
         }
 
         [TestMethod]
-        public void LocalFile_Reload()
+        public void LocalFile_Read()
         {
             using var client = new ConfigCatClient(options =>
             {
@@ -137,7 +137,7 @@ namespace ConfigCat.Client.Tests
         }
 
         [TestMethod]
-        public async Task LocalFileAsync_Reload()
+        public async Task LocalFileAsync_Read()
         {
             using var client = new ConfigCatClient(options =>
             {
@@ -362,7 +362,7 @@ namespace ConfigCat.Client.Tests
             Assert.AreEqual("initial", await client.GetValueAsync("fakeKey", string.Empty));
 
             await WriteContent(SampleFileToCreate, "modified");
-            await Task.Delay(400);
+            await Task.Delay(1100);
 
             Assert.AreEqual("modified", await client.GetValueAsync("fakeKey", string.Empty));
 


### PR DESCRIPTION
### Describe the purpose of your pull request

In this PR I replaced `FileSystemWatcher` with polling on file changes with 1s interval. For example, `FileSystemWatcher` didn't work on Linux in a docker container.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
