### PR TITLE
Add net461 target framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 6.5.1
+- Add net461 to the target frameworks list to force the usage of `System.Text.Json` rather than `Newtonsoft.Json`.
+
 ### 6.5.0
 - Replace `FileSystemWatcher` with file polling in local file override data source.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  build_version: 6.5.0
+  build_version: 6.5.1
 version: $(build_version)-{build}
 image: Visual Studio 2022
 configuration: Release

--- a/src/ConfigCatClient/ConfigCatClient.csproj
+++ b/src/ConfigCatClient/ConfigCatClient.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net45;net461;netstandard2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
     <AssemblyName>ConfigCat.Client</AssemblyName>
     <RootNamespace>ConfigCat.Client</RootNamespace>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
### Describe the purpose of your pull request

Add net461 to the target frameworks list to force the usage of `System.Text.Json` rather than `Newtonsoft.Json`.
Projects using .NET 4.6.1 are falling back to the net45 version of the SDK which is fixed to `Newtonsoft.Json`.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
