### PR TITLE
Use logger wrapper everywhere internally

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  build_version: 6.5.2
+  build_version: 6.5.3
 version: $(build_version)-{build}
 image: Visual Studio 2022
 configuration: Release

--- a/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
+++ b/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
@@ -613,7 +613,7 @@ namespace ConfigCat.Client.Tests
         {
             // Arrange
             
-            var myMock = new FakeConfigService(Mock.Of<IConfigFetcher>(), new CacheParameters(), Mock.Of<ILogger>());
+            var myMock = new FakeConfigService(Mock.Of<IConfigFetcher>(), new CacheParameters(), Mock.Of<ILogger>().AsWrapper());
 
             IConfigCatClient instance = new ConfigCatClient(
                 myMock,
@@ -767,7 +767,7 @@ namespace ConfigCat.Client.Tests
         {
             public byte DisposeCount { get; private set; }
 
-            public FakeConfigService(IConfigFetcher configFetcher, CacheParameters cacheParameters, ILogger log) : base(configFetcher, cacheParameters, log)
+            public FakeConfigService(IConfigFetcher configFetcher, CacheParameters cacheParameters, LoggerWrapper log) : base(configFetcher, cacheParameters, log)
             {
             }
 

--- a/src/ConfigCat.Client.Tests/ConfigServiceTests.cs
+++ b/src/ConfigCat.Client.Tests/ConfigServiceTests.cs
@@ -51,7 +51,7 @@ namespace ConfigCat.Client.Tests
             using var service = new LazyLoadConfigService(
                 fetcherMock.Object,
                 new CacheParameters { ConfigCache = cacheMock.Object },
-                loggerMock.Object,
+                loggerMock.Object.AsWrapper(),
                 defaultExpire);
 
             // Act
@@ -81,7 +81,7 @@ namespace ConfigCat.Client.Tests
             using var service = new LazyLoadConfigService(
                 fetcherMock.Object,
                 new CacheParameters { ConfigCache = cacheMock.Object },
-                loggerMock.Object,
+                loggerMock.Object.AsWrapper(),
                 defaultExpire);
 
             // Act
@@ -124,7 +124,7 @@ namespace ConfigCat.Client.Tests
             using var service = new LazyLoadConfigService(
                 fetcherMock.Object,
                 new CacheParameters { ConfigCache = cacheMock.Object },
-                loggerMock.Object,
+                loggerMock.Object.AsWrapper(),
                 defaultExpire);
 
             // Act
@@ -161,7 +161,7 @@ namespace ConfigCat.Client.Tests
             using var service = new AutoPollConfigService(config,
                 fetcherMock.Object,
                 new CacheParameters { ConfigCache = cacheMock.Object },
-                loggerMock.Object,
+                loggerMock.Object.AsWrapper(),
                 false);
 
             // Act            
@@ -199,7 +199,7 @@ namespace ConfigCat.Client.Tests
             using var service = new AutoPollConfigService(config,
                 fetcherMock.Object,
                 new CacheParameters { ConfigCache = cacheMock.Object },
-                loggerMock.Object,
+                loggerMock.Object.AsWrapper(),
                 true);
 
             // Act            
@@ -236,7 +236,7 @@ namespace ConfigCat.Client.Tests
             using var service = new AutoPollConfigService(config,
                 fetcherMock.Object,
                 new CacheParameters { ConfigCache = cacheMock.Object },
-                loggerMock.Object,
+                loggerMock.Object.AsWrapper(),
                 false);
 
             // Act
@@ -273,7 +273,7 @@ namespace ConfigCat.Client.Tests
             using var service = new AutoPollConfigService(config,
                 fetcherMock.Object,
                 new CacheParameters { ConfigCache = cacheMock.Object },
-                loggerMock.Object,
+                loggerMock.Object.AsWrapper(),
                 false);
 
             config.OnConfigurationChanged += (o, s) => { eventChanged++; };
@@ -308,7 +308,7 @@ namespace ConfigCat.Client.Tests
             using var service = new AutoPollConfigService(config,
                 fetcherMock.Object,
                 new CacheParameters { ConfigCache = cacheMock.Object, CacheKey = "" },
-                loggerMock.Object,
+                loggerMock.Object.AsWrapper(),
                 false);
 
             // Act
@@ -345,7 +345,7 @@ namespace ConfigCat.Client.Tests
             using var service = new AutoPollConfigService(config,
                 fetcherMock.Object,
                 new CacheParameters { ConfigCache = cacheMock.Object },
-                loggerMock.Object,
+                loggerMock.Object.AsWrapper(),
                 false);
 
             // Act
@@ -369,7 +369,7 @@ namespace ConfigCat.Client.Tests
             using var service = new ManualPollConfigService(
                 fetcherMock.Object,
                 new CacheParameters { ConfigCache = cacheMock.Object },
-                loggerMock.Object);
+                loggerMock.Object.AsWrapper());
 
             // Act
 
@@ -409,7 +409,7 @@ namespace ConfigCat.Client.Tests
             using var service = new ManualPollConfigService(
                 fetcherMock.Object,
                 new CacheParameters { ConfigCache = cacheMock.Object },
-                loggerMock.Object);
+                loggerMock.Object.AsWrapper());
 
             // Act
 
@@ -440,7 +440,7 @@ namespace ConfigCat.Client.Tests
                 MockBehavior.Loose,
                 configFetcherMock.Object,
                 new CacheParameters { ConfigCache = new InMemoryConfigCache() },
-                loggerMock.Object)
+                loggerMock.Object.AsWrapper())
             {
                 CallBase = true
             };
@@ -471,7 +471,7 @@ namespace ConfigCat.Client.Tests
                 MockBehavior.Loose,
                 configFetcherMock.Object,
                 new CacheParameters { ConfigCache = new InMemoryConfigCache() },
-                new CounterLogger())
+                new CounterLogger().AsWrapper())
             {
                 CallBase = true
             };

--- a/src/ConfigCat.Client.Tests/DataGovernanceTests.cs
+++ b/src/ConfigCat.Client.Tests/DataGovernanceTests.cs
@@ -60,7 +60,7 @@ namespace ConfigCat.Client.Tests
             IConfigFetcher fetcher = new HttpConfigFetcher(
                 configuration.CreateUri(),
                 "DEMO",
-                Mock.Of<ILogger>(),
+                Mock.Of<ILogger>().AsWrapper(),
                 handlerMock.Object,
                 Mock.Of<IConfigDeserializer>(),
                 configuration.IsCustomBaseUrl,
@@ -377,7 +377,7 @@ namespace ConfigCat.Client.Tests
             IConfigFetcher fetcher = new HttpConfigFetcher(
                 fetchConfig.CreateUri(),
                 "DEMO",
-                Mock.Of<ILogger>(),
+                Mock.Of<ILogger>().AsWrapper(),
                 handlerMock.Object,
                 new ConfigDeserializer(),
                 fetchConfig.IsCustomBaseUrl,

--- a/src/ConfigCat.Client.Tests/Fakes/LoggerExtensions.cs
+++ b/src/ConfigCat.Client.Tests/Fakes/LoggerExtensions.cs
@@ -1,0 +1,10 @@
+﻿namespace ConfigCat.Client
+{
+    internal static class LoggerExtensions
+    {
+        public static LoggerWrapper AsWrapper(this ILogger logger)
+        {
+            return new LoggerWrapper(logger);
+        }
+    }
+}

--- a/src/ConfigCat.Client.Tests/HttpConfigFetcherTests.cs
+++ b/src/ConfigCat.Client.Tests/HttpConfigFetcherTests.cs
@@ -16,7 +16,7 @@ namespace ConfigCat.Client.Tests
 
             var myHandler = new FakeHttpClientHandler();
 
-            var instance = new HttpConfigFetcher(new Uri("http://example.com"), "1.0", new CounterLogger(), myHandler, Mock.Of<IConfigDeserializer>(), false,
+            var instance = new HttpConfigFetcher(new Uri("http://example.com"), "1.0", new CounterLogger().AsWrapper(), myHandler, Mock.Of<IConfigDeserializer>(), false,
                 TimeSpan.FromSeconds(30));
 
             // Act
@@ -35,7 +35,7 @@ namespace ConfigCat.Client.Tests
 
             var myHandler = new FakeHttpClientHandler();
 
-            var instance = new HttpConfigFetcher(new Uri("http://example.com"), "1.0", new CounterLogger(), myHandler, Mock.Of<IConfigDeserializer>(), false,
+            var instance = new HttpConfigFetcher(new Uri("http://example.com"), "1.0", new CounterLogger().AsWrapper(), myHandler, Mock.Of<IConfigDeserializer>(), false,
                 TimeSpan.FromSeconds(30));
 
             // Act
@@ -54,7 +54,7 @@ namespace ConfigCat.Client.Tests
 
             var myHandler = new FakeHttpClientHandler(HttpStatusCode.Forbidden);
 
-            var instance = new HttpConfigFetcher(new Uri("http://example.com"), "1.0", new CounterLogger(), myHandler, Mock.Of<IConfigDeserializer>(), false,
+            var instance = new HttpConfigFetcher(new Uri("http://example.com"), "1.0", new CounterLogger().AsWrapper(), myHandler, Mock.Of<IConfigDeserializer>(), false,
                 TimeSpan.FromSeconds(30));
 
             var lastConfig = new ProjectConfig("{ }", DateTime.UtcNow, "\"ETAG\"");
@@ -75,7 +75,7 @@ namespace ConfigCat.Client.Tests
 
             var myHandler = new ExceptionThrowerHttpClientHandler(new WebException());
 
-            var instance = new HttpConfigFetcher(new Uri("http://example.com"), "1.0", new CounterLogger(), myHandler, Mock.Of<IConfigDeserializer>(), false,
+            var instance = new HttpConfigFetcher(new Uri("http://example.com"), "1.0", new CounterLogger().AsWrapper(), myHandler, Mock.Of<IConfigDeserializer>(), false,
                 TimeSpan.FromSeconds(30));
 
             var lastConfig = new ProjectConfig("{ }", DateTime.UtcNow, "\"ETAG\"");

--- a/src/ConfigCatClient/ConfigService/AutoPollConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/AutoPollConfigService.cs
@@ -18,7 +18,7 @@ namespace ConfigCat.Client.ConfigService
             AutoPoll configuration,
             IConfigFetcher configFetcher,
             CacheParameters cacheParameters,
-            ILogger logger) : this(configuration, configFetcher, cacheParameters, logger, true)
+            LoggerWrapper logger) : this(configuration, configFetcher, cacheParameters, logger, true)
         { }
 
         // For test purposes only
@@ -26,7 +26,7 @@ namespace ConfigCat.Client.ConfigService
             AutoPoll configuration,
             IConfigFetcher configFetcher,
             CacheParameters cacheParameters,
-            ILogger logger,
+            LoggerWrapper logger,
             bool startTimer
             ) : base(configFetcher, cacheParameters, logger)
         {

--- a/src/ConfigCatClient/ConfigService/ConfigServiceBase.cs
+++ b/src/ConfigCatClient/ConfigService/ConfigServiceBase.cs
@@ -13,11 +13,11 @@ namespace ConfigCat.Client.ConfigService
         protected readonly IConfigCache ConfigCache; // Backward compatibility, it'll be changed to IConfigCatCache later.
 #pragma warning restore CS0618 // Type or member is obsolete
 
-        protected readonly ILogger Log;
+        protected readonly LoggerWrapper Log;
 
         protected readonly string CacheKey;
 
-        protected ConfigServiceBase(IConfigFetcher configFetcher, CacheParameters cacheParameters, ILogger log)
+        protected ConfigServiceBase(IConfigFetcher configFetcher, CacheParameters cacheParameters, LoggerWrapper log)
         {
             this.ConfigFetcher = configFetcher;
             this.ConfigCache = cacheParameters.ConfigCache;

--- a/src/ConfigCatClient/ConfigService/LazyLoadConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/LazyLoadConfigService.cs
@@ -9,7 +9,7 @@ namespace ConfigCat.Client.ConfigService
     {
         private readonly TimeSpan cacheTimeToLive;        
 
-        internal LazyLoadConfigService(IConfigFetcher configFetcher, CacheParameters cacheParameters, ILogger logger, TimeSpan cacheTimeToLive)
+        internal LazyLoadConfigService(IConfigFetcher configFetcher, CacheParameters cacheParameters, LoggerWrapper logger, TimeSpan cacheTimeToLive)
             : base(configFetcher, cacheParameters, logger)
         {   
             this.cacheTimeToLive = cacheTimeToLive;

--- a/src/ConfigCatClient/ConfigService/ManualPollConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/ManualPollConfigService.cs
@@ -6,7 +6,7 @@ namespace ConfigCat.Client.ConfigService
 {
     internal sealed class ManualPollConfigService : ConfigServiceBase, IConfigService
     {
-        internal ManualPollConfigService(IConfigFetcher configFetcher, CacheParameters cacheParameters, ILogger logger)
+        internal ManualPollConfigService(IConfigFetcher configFetcher, CacheParameters cacheParameters, LoggerWrapper logger)
             : base(configFetcher, cacheParameters, logger) { }
 
         public ProjectConfig GetConfig()

--- a/src/ConfigCatClient/Evaluate/RolloutEvaluator.cs
+++ b/src/ConfigCatClient/Evaluate/RolloutEvaluator.cs
@@ -13,9 +13,9 @@ namespace ConfigCat.Client.Evaluate
 {
     internal class RolloutEvaluator : IRolloutEvaluator
     {
-        private readonly ILogger log;
+        private readonly LoggerWrapper log;
 
-        public RolloutEvaluator(ILogger logger)
+        public RolloutEvaluator(LoggerWrapper logger)
         {
             this.log = logger;
         }

--- a/src/ConfigCatClient/HttpConfigFetcher.cs
+++ b/src/ConfigCatClient/HttpConfigFetcher.cs
@@ -24,7 +24,7 @@ namespace ConfigCat.Client
 
         private Uri requestUri;
 
-        public HttpConfigFetcher(Uri requestUri, string productVersion, ILogger logger,
+        public HttpConfigFetcher(Uri requestUri, string productVersion, LoggerWrapper logger,
             HttpClientHandler httpClientHandler, IConfigDeserializer deserializer, bool isCustomUri, TimeSpan timeout)
         {
             this.requestUri = requestUri;

--- a/src/ConfigCatClient/HttpConfigFetcher.cs
+++ b/src/ConfigCatClient/HttpConfigFetcher.cs
@@ -13,7 +13,7 @@ namespace ConfigCat.Client
     {
         private readonly object lck = new();
         private readonly string productVersion;
-        private readonly ILogger log;
+        private readonly LoggerWrapper log;
 
         private readonly HttpClientHandler httpClientHandler;
         private readonly IConfigDeserializer deserializer;

--- a/src/ConfigCatClient/Override/FlagOverrides.cs
+++ b/src/ConfigCatClient/Override/FlagOverrides.cs
@@ -35,7 +35,7 @@ namespace ConfigCat.Client
         /// </summary>
         public OverrideBehaviour OverrideBehaviour { get; private set; }
 
-        internal IOverrideDataSource BuildDataSource(ILogger logger)
+        internal IOverrideDataSource BuildDataSource(LoggerWrapper logger)
         {
             if (this.dictionary != null)
                 return new LocalDictionaryDataSource(this.dictionary);

--- a/src/ConfigCatClient/Override/LocalFileDataSource.cs
+++ b/src/ConfigCatClient/Override/LocalFileDataSource.cs
@@ -16,12 +16,12 @@ namespace ConfigCat.Client.Override
 
         private DateTime fileLastWriteTime;
         private readonly string fullPath;
-        private readonly ILogger logger;
+        private readonly LoggerWrapper logger;
         private readonly CancellationTokenSource cancellationTokenSource = new();
 
         private volatile IDictionary<string, Setting> overrideValues;
 
-        public LocalFileDataSource(string filePath, bool autoReload, ILogger logger)
+        public LocalFileDataSource(string filePath, bool autoReload, LoggerWrapper logger)
         {
             if (!File.Exists(filePath))
             {


### PR DESCRIPTION
### Describe the purpose of your pull request

Previously, the SDK used both the `ILogger` from it's configuration options and an instantiated `LoggerWrapper` for logging. In this PR I'm enforcing the usage of only the `LoggerWrapper`.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
