### PR TITLE
Fixes .NET 4.5 tests

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -12,10 +12,18 @@ furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
-This repository includes two files originally copied from https://github.com/maxhauser/semver
-repository: https://github.com/maxhauser/semver/blob/master/Semver/IntExtensions.cs and
-https://github.com/maxhauser/semver/blob/master/Semver/SemVersion.cs. The
-original versions of the files are MIT licensed. See the file headers for details.
+This repository includes several pieces of source code authored by other parties.
+The files containing such source code are the following:
+* src/ConfigCatClient/Versioning/SemVersion.cs, which
+  is originally available at https://github.com/maxhauser/semver/blob/v2.2.0/Semver/SemVersion.cs and
+  is licensed under MIT license (see https://github.com/maxhauser/semver/blob/v2.2.0/License.txt).
+* src/ConfigCatClient/Versioning/IntExtensions.cs, which
+  is originally available at https://github.com/maxhauser/semver/blob/v2.2.0/Semver/Utility/IntExtensions.cs and
+  is licensed under MIT license (see https://github.com/maxhauser/semver/blob/v2.2.0/License.txt).
+* src/ConfigCat.Client.Tests/ModuleInitializerAttribute.cs, which
+  is originally available at https://github.com/dotnet/runtime/blob/v6.0.9/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ModuleInitializerAttribute.cs and
+  is licensed under MIT license (see https://github.com/dotnet/runtime/blob/main/LICENSE.TXT).
+See the file headers for details.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/src/ConfigCat.Client.Tests/ModuleInitializer.cs
+++ b/src/ConfigCat.Client.Tests/ModuleInitializer.cs
@@ -1,0 +1,18 @@
+﻿using System.Net;
+using System.Runtime.CompilerServices;
+
+namespace ConfigCat.Client.Tests
+{
+    internal class ModuleInitializer
+    {
+        [ModuleInitializer]
+        internal static void Setup()
+        {
+#if NET45
+            // TLS 1.2 was not enabled before .NET 4.6 by default (see https://stackoverflow.com/a/58195987/8656352),
+            // so we need to do this because CDN servers are configured to require TLS 1.2+ currently.
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+#endif
+        }
+    }
+}

--- a/src/ConfigCat.Client.Tests/ModuleInitializerAttribute.cs
+++ b/src/ConfigCat.Client.Tests/ModuleInitializerAttribute.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// Source: https://github.com/dotnet/runtime/blob/v6.0.9/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ModuleInitializerAttribute.cs
-
 #if !NET5_0_OR_GREATER
 
 namespace System.Runtime.CompilerServices

--- a/src/ConfigCat.Client.Tests/ModuleInitializerAttribute.cs
+++ b/src/ConfigCat.Client.Tests/ModuleInitializerAttribute.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Source: https://github.com/dotnet/runtime/blob/v6.0.9/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ModuleInitializerAttribute.cs
+
+#if !NET5_0_OR_GREATER
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Used to indicate to the compiler that a method should be called
+    /// in its containing module's initializer.
+    /// </summary>
+    /// <remarks>
+    /// When one or more valid methods
+    /// with this attribute are found in a compilation, the compiler will
+    /// emit a module initializer which calls each of the attributed methods.
+    ///
+    /// Certain requirements are imposed on any method targeted with this attribute:
+    /// - The method must be `static`.
+    /// - The method must be an ordinary member method, as opposed to a property accessor, constructor, local function, etc.
+    /// - The method must be parameterless.
+    /// - The method must return `void`.
+    /// - The method must not be generic or be contained in a generic type.
+    /// - The method's effective accessibility must be `internal` or `public`.
+    ///
+    /// The specification for module initializers in the .NET runtime can be found here:
+    /// https://github.com/dotnet/runtime/blob/main/docs/design/specs/Ecma-335-Augments.md#module-initializer
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    internal sealed class ModuleInitializerAttribute : Attribute
+    {
+        public ModuleInitializerAttribute()
+        {
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
### Describe the purpose of your pull request

As it turned out, configuration of CDN servers has been changed recently to disallow deprecated security protocols older than TLS 1.2. This change broke a bunch of test cases because [.NET 4.5 does not allow TLS 1.2 by default](https://stackoverflow.com/a/58195987/8656352).

This PR proposes a solution to the problem and also adds a log message which guides the end user in the right direction when they encounter this error.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
