### PR TITLE
Offline mode feature

### DIFF
--- a/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
+++ b/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
@@ -1017,7 +1017,7 @@ namespace ConfigCat.Client.Tests
         {
             public byte DisposeCount { get; private set; }
 
-            public FakeConfigService(IConfigFetcher configFetcher, CacheParameters cacheParameters, LoggerWrapper log) : base(configFetcher, cacheParameters, log)
+            public FakeConfigService(IConfigFetcher configFetcher, CacheParameters cacheParameters, LoggerWrapper log) : base(configFetcher, cacheParameters, log, isOffline: false)
             {
             }
 

--- a/src/ConfigCat.Client.Tests/ConfigServiceTests.cs
+++ b/src/ConfigCat.Client.Tests/ConfigServiceTests.cs
@@ -162,7 +162,7 @@ namespace ConfigCat.Client.Tests
                 fetcherMock.Object,
                 new CacheParameters { ConfigCache = cacheMock.Object },
                 loggerMock.Object.AsWrapper(),
-                false);
+                startTimer: false);
 
             // Act            
 
@@ -200,7 +200,7 @@ namespace ConfigCat.Client.Tests
                 fetcherMock.Object,
                 new CacheParameters { ConfigCache = cacheMock.Object },
                 loggerMock.Object.AsWrapper(),
-                true);
+                startTimer: true);
 
             // Act            
 
@@ -237,7 +237,7 @@ namespace ConfigCat.Client.Tests
                 fetcherMock.Object,
                 new CacheParameters { ConfigCache = cacheMock.Object },
                 loggerMock.Object.AsWrapper(),
-                false);
+                startTimer: false);
 
             // Act
 
@@ -274,7 +274,7 @@ namespace ConfigCat.Client.Tests
                 fetcherMock.Object,
                 new CacheParameters { ConfigCache = cacheMock.Object },
                 loggerMock.Object.AsWrapper(),
-                false);
+                startTimer: false);
 
             config.OnConfigurationChanged += (o, s) => { eventChanged++; };
 
@@ -309,7 +309,7 @@ namespace ConfigCat.Client.Tests
                 fetcherMock.Object,
                 new CacheParameters { ConfigCache = cacheMock.Object, CacheKey = "" },
                 loggerMock.Object.AsWrapper(),
-                false);
+                startTimer: false);
 
             // Act
             await Task.Delay(TimeSpan.FromSeconds(1));
@@ -346,7 +346,7 @@ namespace ConfigCat.Client.Tests
                 fetcherMock.Object,
                 new CacheParameters { ConfigCache = cacheMock.Object },
                 loggerMock.Object.AsWrapper(),
-                false);
+                startTimer: false);
 
             // Act
             await Task.Delay(TimeSpan.FromSeconds(1));
@@ -438,9 +438,13 @@ namespace ConfigCat.Client.Tests
 
             var configServiceMock = new Mock<ConfigServiceBase>(
                 MockBehavior.Loose,
-                configFetcherMock.Object,
-                new CacheParameters { ConfigCache = new InMemoryConfigCache() },
-                loggerMock.Object.AsWrapper())
+                new object[]
+                {
+                    configFetcherMock.Object,
+                    new CacheParameters { ConfigCache = new InMemoryConfigCache() },
+                    loggerMock.Object.AsWrapper(),
+                    false
+                })
             {
                 CallBase = true
             };
@@ -469,9 +473,13 @@ namespace ConfigCat.Client.Tests
 
             var configServiceMock = new Mock<ConfigServiceBase>(
                 MockBehavior.Loose,
-                configFetcherMock.Object,
-                new CacheParameters { ConfigCache = new InMemoryConfigCache() },
-                new CounterLogger().AsWrapper())
+                new object[]
+                {
+                    configFetcherMock.Object,
+                    new CacheParameters { ConfigCache = new InMemoryConfigCache() },
+                    new CounterLogger().AsWrapper(),
+                    false
+                })
             {
                 CallBase = true
             };

--- a/src/ConfigCatClient/ConfigCatClient.cs
+++ b/src/ConfigCatClient/ConfigCatClient.cs
@@ -161,6 +161,7 @@ namespace ConfigCat.Client
                             configuration.HttpTimeout),
                         cacheParameters,
                         this.log,
+                        configuration.Offline,
                         clientWeakRef)
                 : new EmptyConfigService(this.log);
         }
@@ -595,7 +596,7 @@ namespace ConfigCat.Client
             }
         }
 
-        private static IConfigService DetermineConfigService(PollingMode pollingMode, HttpConfigFetcher fetcher, CacheParameters cacheParameters, LoggerWrapper logger, WeakReference<IConfigCatClient> clientWeakRef)
+        private static IConfigService DetermineConfigService(PollingMode pollingMode, HttpConfigFetcher fetcher, CacheParameters cacheParameters, LoggerWrapper logger, bool isOffline, WeakReference<IConfigCatClient> clientWeakRef)
         {
             return pollingMode switch
             {
@@ -603,14 +604,17 @@ namespace ConfigCat.Client
                     fetcher,
                     cacheParameters,
                     logger,
+                    isOffline,
                     clientWeakRef),
                 LazyLoad lazyLoad => new LazyLoadConfigService(fetcher,
                     cacheParameters,
                     logger,
-                    lazyLoad.CacheTimeToLive),
+                    lazyLoad.CacheTimeToLive,
+                    isOffline),
                 ManualPoll => new ManualPollConfigService(fetcher,
                     cacheParameters,
-                    logger),
+                    logger,
+                    isOffline),
                 _ => throw new ArgumentException("Invalid configuration type."),
             };
         }

--- a/src/ConfigCatClient/ConfigCatClient.cs
+++ b/src/ConfigCatClient/ConfigCatClient.cs
@@ -163,7 +163,7 @@ namespace ConfigCat.Client
                         this.log,
                         configuration.Offline,
                         clientWeakRef)
-                : new EmptyConfigService(this.log);
+                : new NullConfigService(this.log);
         }
 
         /// <summary>

--- a/src/ConfigCatClient/ConfigCatClient.cs
+++ b/src/ConfigCatClient/ConfigCatClient.cs
@@ -162,7 +162,7 @@ namespace ConfigCat.Client
                         cacheParameters,
                         this.log,
                         clientWeakRef)
-                : new EmptyConfigService();
+                : new EmptyConfigService(this.log);
         }
 
         /// <summary>
@@ -631,6 +631,21 @@ namespace ConfigCat.Client
         public void ClearDefaultUser()
         {
             this.defaultUser = null;
+        }
+
+        /// <inheritdoc />
+        public bool IsOffline => this.configService.IsOffline;
+
+        /// <inheritdoc />
+        public void SetOnline()
+        {
+            this.configService.SetOnline();
+        }
+
+        /// <inheritdoc />
+        public void SetOffline()
+        {
+            this.configService.SetOffline();
         }
     }
 }

--- a/src/ConfigCatClient/ConfigService/AutoPollConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/AutoPollConfigService.cs
@@ -20,7 +20,8 @@ namespace ConfigCat.Client.ConfigService
             IConfigFetcher configFetcher,
             CacheParameters cacheParameters,
             LoggerWrapper logger,
-            WeakReference<IConfigCatClient> clientWeakRef = null) : this(configuration, configFetcher, cacheParameters, logger, startTimer: true, clientWeakRef)
+            bool isOffline = false,
+            WeakReference<IConfigCatClient> clientWeakRef = null) : this(configuration, configFetcher, cacheParameters, logger, startTimer: true, isOffline, clientWeakRef)
         { }
 
         // For test purposes only
@@ -30,14 +31,14 @@ namespace ConfigCat.Client.ConfigService
             CacheParameters cacheParameters,
             LoggerWrapper logger,
             bool startTimer,
-            WeakReference<IConfigCatClient> clientWeakRef = null
-            ) : base(configFetcher, cacheParameters, logger)
+            bool isOffline = false,
+            WeakReference<IConfigCatClient> clientWeakRef = null) : base(configFetcher, cacheParameters, logger, isOffline)
         {
             this.configuration = configuration;
             this.maxInitWaitExpire = DateTimeOffset.UtcNow.Add(configuration.MaxInitWaitTime);
             this.clientWeakRef = clientWeakRef;
 
-            if (startTimer)
+            if (!isOffline && startTimer)
             {
                 StartScheduler(configuration.PollInterval);
             }

--- a/src/ConfigCatClient/ConfigService/AutoPollConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/AutoPollConfigService.cs
@@ -13,7 +13,7 @@ namespace ConfigCat.Client.ConfigService
         private readonly ManualResetEventSlim initializedEventSlim = new(false);
         private readonly AutoPoll configuration;
         private readonly WeakReference<IConfigCatClient> clientWeakRef;
-        private readonly CancellationTokenSource timerCancellationTokenSource = new();
+        private CancellationTokenSource timerCancellationTokenSource = new();
 
         internal AutoPollConfigService(
             AutoPoll configuration,
@@ -43,29 +43,49 @@ namespace ConfigCat.Client.ConfigService
             }
         }
 
-        protected override void Dispose(bool disposing)
+        protected override void DisposeSynchronized(bool disposing)
         {
             // Background work should stop under all circumstances
             this.timerCancellationTokenSource.Cancel();
 
             if (disposing)
             {
+                this.timerCancellationTokenSource.Dispose();
+                this.timerCancellationTokenSource = null;
+            }
+
+            base.DisposeSynchronized(disposing);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
                 this.initializedEventSlim.Dispose();
             }
+
             base.Dispose(disposing);
+        }
+
+        internal bool WaitForInitialization(TimeSpan timeout)
+        {
+            return this.initializedEventSlim.Wait(timeout);
         }
 
         public ProjectConfig GetConfig()
         {
             if (this.ConfigCache is IConfigCatCache cache)
             {
-                var delay = this.maxInitWaitExpire.Subtract(DateTimeOffset.UtcNow);
                 var cacheConfig = cache.Get(base.CacheKey);
 
-                if (delay > TimeSpan.Zero && cacheConfig.Equals(ProjectConfig.Empty))
+                if (!IsOffline)
                 {
-                    initializedEventSlim.Wait(delay);
-                    cacheConfig = cache.Get(base.CacheKey);
+                    var delay = this.maxInitWaitExpire.Subtract(DateTimeOffset.UtcNow);
+                    if (delay > TimeSpan.Zero && cacheConfig.Equals(ProjectConfig.Empty))
+                    {
+                        WaitForInitialization(delay);
+                        cacheConfig = cache.Get(base.CacheKey);
+                    }
                 }
 
                 return cacheConfig;
@@ -77,13 +97,16 @@ namespace ConfigCat.Client.ConfigService
 
         public async Task<ProjectConfig> GetConfigAsync()
         {
-            var delay = this.maxInitWaitExpire.Subtract(DateTimeOffset.UtcNow);
             var cacheConfig = await this.ConfigCache.GetAsync(base.CacheKey).ConfigureAwait(false);
 
-            if (delay > TimeSpan.Zero && cacheConfig.Equals(ProjectConfig.Empty))
+            if (!IsOffline)
             {
-                initializedEventSlim.Wait(delay);
-                cacheConfig = await this.ConfigCache.GetAsync(base.CacheKey).ConfigureAwait(false);
+                var delay = this.maxInitWaitExpire.Subtract(DateTimeOffset.UtcNow);
+                if (delay > TimeSpan.Zero && cacheConfig.Equals(ProjectConfig.Empty))
+                {
+                    WaitForInitialization(delay);
+                    cacheConfig = await this.ConfigCache.GetAsync(base.CacheKey).ConfigureAwait(false);
+                }
             }
 
             return cacheConfig;
@@ -94,15 +117,22 @@ namespace ConfigCat.Client.ConfigService
             // check for the new cache interface until we remove the old IConfigCache.
             if (this.ConfigCache is IConfigCatCache cache)
             {
-                var latestConfig = cache.Get(base.CacheKey);
-                var newConfig = this.ConfigFetcher.Fetch(latestConfig);
-
-                if (!latestConfig.Equals(newConfig) && !newConfig.Equals(ProjectConfig.Empty))
+                if (!IsOffline)
                 {
-                    this.Log.Debug("config changed");
-                    cache.Set(base.CacheKey, newConfig);
-                    this.configuration.RaiseOnConfigurationChanged(this, OnConfigurationChangedEventArgs.Empty);
-                    initializedEventSlim.Set();
+                    var latestConfig = cache.Get(base.CacheKey);
+                    var newConfig = this.ConfigFetcher.Fetch(latestConfig);
+
+                    if (!latestConfig.Equals(newConfig) && !newConfig.Equals(ProjectConfig.Empty))
+                    {
+                        this.Log.Debug("config changed");
+                        cache.Set(base.CacheKey, newConfig);
+                        this.configuration.RaiseOnConfigurationChanged(this, OnConfigurationChangedEventArgs.Empty);
+                        initializedEventSlim.Set();
+                    }
+                }
+                else
+                {
+                    this.Log.OfflineModeWarning();
                 }
 
                 return;
@@ -112,7 +142,7 @@ namespace ConfigCat.Client.ConfigService
             Syncer.Sync(this.RefreshConfigAsync);
         }
 
-        public async Task RefreshConfigAsync()
+        private async Task RefreshConfigCoreAsync()
         {
             var latestConfig = await this.ConfigCache.GetAsync(base.CacheKey).ConfigureAwait(false);
             var newConfig = await this.ConfigFetcher.FetchAsync(latestConfig).ConfigureAwait(false);
@@ -126,18 +156,45 @@ namespace ConfigCat.Client.ConfigService
             }
         }
 
+        public async Task RefreshConfigAsync()
+        {
+            if (!IsOffline)
+            {
+                await RefreshConfigCoreAsync().ConfigureAwait(false);
+            }
+            else
+            {
+                this.Log.OfflineModeWarning();
+            }
+        }
+
+        protected override void SetOnlineCoreSynchronized()
+        {
+            StartScheduler(configuration.PollInterval);
+        }
+
+        protected override void SetOfflineCoreSynchronized()
+        {
+            this.timerCancellationTokenSource.Cancel();
+            this.timerCancellationTokenSource.Dispose();
+            this.timerCancellationTokenSource = new CancellationTokenSource();
+        }
+
         private void StartScheduler(TimeSpan interval)
         {
             Task.Run(async () =>
             {
-                while (!this.timerCancellationTokenSource.IsCancellationRequested && (this.clientWeakRef is null || this.clientWeakRef.IsAlive()))
+                while ((this.clientWeakRef is null || this.clientWeakRef.IsAlive()) && Synchronize(static @this => @this.timerCancellationTokenSource, this) is CancellationTokenSource cts && !cts.IsCancellationRequested)
                 {
                     try
                     {
                         var scheduledNextTime = DateTimeOffset.UtcNow.Add(interval);
                         try
                         {
-                            await RefreshConfigAsync().ConfigureAwait(false);
+                            if (!IsOffline)
+                            {
+                                await RefreshConfigCoreAsync().ConfigureAwait(false);
+                            }
                         }
                         catch (Exception exception)
                         {
@@ -150,7 +207,7 @@ namespace ConfigCat.Client.ConfigService
                                 var realNextTime = scheduledNextTime.Subtract(DateTimeOffset.UtcNow);
                                 if (realNextTime > TimeSpan.Zero)
                                 {
-                                    await Task.Delay(realNextTime, this.timerCancellationTokenSource.Token).ConfigureAwait(false);
+                                    await Task.Delay(realNextTime, cts.Token).ConfigureAwait(false);
                                 }
                             }
                         }

--- a/src/ConfigCatClient/ConfigService/ConfigServiceBase.cs
+++ b/src/ConfigCatClient/ConfigService/ConfigServiceBase.cs
@@ -5,7 +5,15 @@ namespace ConfigCat.Client.ConfigService
 {
     internal abstract class ConfigServiceBase : IDisposable
     {
-        private bool disposedValue;
+        protected internal enum Status
+        {
+            Online,
+            Offline,
+            Disposed,
+        }
+ 
+        private Status status;
+        private readonly object syncObj = new object();
 
         protected readonly IConfigFetcher ConfigFetcher;
 
@@ -23,22 +31,108 @@ namespace ConfigCat.Client.ConfigService
             this.ConfigCache = cacheParameters.ConfigCache;
             this.CacheKey = cacheParameters.CacheKey;
             this.Log = log;
-        }       
+        }
+
+        /// <remarks>
+        /// Note for inheritors. Beware, this method is called within a lock statement.
+        /// </remarks>
+        protected virtual void DisposeSynchronized(bool disposing) { }
 
         protected virtual void Dispose(bool disposing)
         {
-            if (disposedValue) return;
             if (disposing && ConfigFetcher is IDisposable disposable)
             {
                 disposable.Dispose();
             }
-
-            disposedValue = true;
         }
-                
+
         public void Dispose()
         {
-            Dispose(true);         
+            lock (this.syncObj)
+            {
+                if (this.status == Status.Disposed)
+                {
+                    return;
+                }
+
+                this.status = Status.Disposed;
+
+                DisposeSynchronized(true);
+            }
+
+            Dispose(true);
+        }
+
+        public bool IsOffline
+        {
+            get
+            {
+                lock (this.syncObj)
+                {
+                    return this.status != Status.Online;
+                }
+            }
+        }
+
+        /// <remarks>
+        /// Note for inheritors. Beware, this method is called within a lock statement.
+        /// </remarks>
+        protected virtual void SetOnlineCoreSynchronized() { }
+
+        public void SetOnline()
+        {
+            Action<ILogger> logAction = null;
+
+            lock (this.syncObj)
+            {
+                if (this.status == Status.Offline)
+                {
+                    SetOnlineCoreSynchronized();
+                    this.status = Status.Online;
+                    logAction = static logger => logger.StatusChange(Status.Online);
+                }
+                else if (this.status == Status.Disposed)
+                {
+                    logAction = static logger => logger.DisposedWarning(nameof(SetOnline) + "()");
+                    return;
+                }
+            }
+
+            logAction?.Invoke(this.Log);
+        }
+
+        /// <remarks>
+        /// Note for inheritors. Beware, this method is called within a lock statement.
+        /// </remarks>
+        protected virtual void SetOfflineCoreSynchronized() { }
+
+        public void SetOffline()
+        {
+            Action<ILogger> logAction = null;
+
+            lock (this.syncObj)
+            {
+                if (this.status == Status.Online)
+                {
+                    SetOfflineCoreSynchronized();
+                    this.status = Status.Offline;
+                    logAction = static logger => logger.StatusChange(Status.Offline);
+                }
+                else if (this.status == Status.Disposed)
+                {
+                    logAction = static logger => logger.DisposedWarning(nameof(SetOffline) + "()");
+                }
+            }
+
+            logAction?.Invoke(this.Log);
+        }
+
+        protected TResult Synchronize<TState, TResult>(Func<TState, TResult> func, TState state)
+        {
+            lock (this.syncObj)
+            {
+                return func(state);
+            }
         }
     }
 }

--- a/src/ConfigCatClient/ConfigService/ConfigServiceBase.cs
+++ b/src/ConfigCatClient/ConfigService/ConfigServiceBase.cs
@@ -25,12 +25,13 @@ namespace ConfigCat.Client.ConfigService
 
         protected readonly string CacheKey;
 
-        protected ConfigServiceBase(IConfigFetcher configFetcher, CacheParameters cacheParameters, LoggerWrapper log)
+        protected ConfigServiceBase(IConfigFetcher configFetcher, CacheParameters cacheParameters, LoggerWrapper log, bool isOffline)
         {
             this.ConfigFetcher = configFetcher;
             this.ConfigCache = cacheParameters.ConfigCache;
             this.CacheKey = cacheParameters.CacheKey;
             this.Log = log;
+            this.status = isOffline ? Status.Offline : Status.Online;
         }
 
         /// <remarks>

--- a/src/ConfigCatClient/ConfigService/ConfigServiceLoggerExtensions.cs
+++ b/src/ConfigCatClient/ConfigService/ConfigServiceLoggerExtensions.cs
@@ -1,0 +1,20 @@
+﻿namespace ConfigCat.Client.ConfigService
+{
+    internal static class ConfigServiceLoggerExtensions
+    {
+        public static void StatusChange(this ILogger logger, ConfigServiceBase.Status status)
+        {
+            logger.Debug($"Switched to {status.ToString().ToUpperInvariant()} mode.");
+        }
+
+        public static void OfflineModeWarning(this ILogger logger)
+        {
+            logger.Warning("Client is in offline mode, it can't initiate HTTP calls.");
+        }
+
+        public static void DisposedWarning(this ILogger logger, string methodName)
+        {
+            logger.Warning($"Client has already been disposed, thus {methodName} has no effect.");
+        }
+    }
+}

--- a/src/ConfigCatClient/ConfigService/EmptyConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/EmptyConfigService.cs
@@ -4,6 +4,13 @@ namespace ConfigCat.Client.ConfigService
 {
     internal sealed class EmptyConfigService : IConfigService
     {
+        private readonly LoggerWrapper log;
+
+        public EmptyConfigService(LoggerWrapper log)
+        {
+            this.log = log;
+        }
+
         public ProjectConfig GetConfig() => ProjectConfig.Empty;
 
         public Task<ProjectConfig> GetConfigAsync() => Task.FromResult(ProjectConfig.Empty);
@@ -11,5 +18,14 @@ namespace ConfigCat.Client.ConfigService
         public void RefreshConfig() { /* do nothing */ }
 
         public Task RefreshConfigAsync() => Task.FromResult(0);
+
+        public bool IsOffline => true;
+
+        public void SetOffline() { /* do nothing */ }
+
+        public void SetOnline() 
+        {
+            this.log.Warning($"Client is configured to use Local/Offline mode, thus {nameof(SetOnline)}() has no effect.");
+        }
     }
 }

--- a/src/ConfigCatClient/ConfigService/IConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/IConfigService.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace ConfigCat.Client.ConfigService
 {
@@ -11,5 +12,11 @@ namespace ConfigCat.Client.ConfigService
         Task RefreshConfigAsync();
 
         void RefreshConfig();
+
+        bool IsOffline { get; }
+
+        void SetOnline();
+
+        void SetOffline();
     }
 }

--- a/src/ConfigCatClient/ConfigService/LazyLoadConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/LazyLoadConfigService.cs
@@ -9,8 +9,8 @@ namespace ConfigCat.Client.ConfigService
     {
         private readonly TimeSpan cacheTimeToLive;
         
-        internal LazyLoadConfigService(IConfigFetcher configFetcher, CacheParameters cacheParameters, LoggerWrapper logger, TimeSpan cacheTimeToLive)
-            : base(configFetcher, cacheParameters, logger)
+        internal LazyLoadConfigService(IConfigFetcher configFetcher, CacheParameters cacheParameters, LoggerWrapper logger, TimeSpan cacheTimeToLive, bool isOffline = false)
+            : base(configFetcher, cacheParameters, logger, isOffline)
         {
             this.cacheTimeToLive = cacheTimeToLive;
         }

--- a/src/ConfigCatClient/ConfigService/ManualPollConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/ManualPollConfigService.cs
@@ -31,9 +31,16 @@ namespace ConfigCat.Client.ConfigService
             // check for the new cache interface until we remove the old IConfigCache.
             if (this.ConfigCache is IConfigCatCache cache)
             {
-                var latestConfig = cache.Get(base.CacheKey);
-                var newConfig = this.ConfigFetcher.Fetch(latestConfig);
-                cache.Set(base.CacheKey, newConfig);
+                if (!IsOffline)
+                {
+                    var latestConfig = cache.Get(base.CacheKey);
+                    var newConfig = this.ConfigFetcher.Fetch(latestConfig);
+                    cache.Set(base.CacheKey, newConfig);
+                }
+                else
+                {
+                    this.Log.OfflineModeWarning();
+                }
 
                 return;
             }
@@ -44,9 +51,16 @@ namespace ConfigCat.Client.ConfigService
 
         public async Task RefreshConfigAsync()
         {
-            var config = await this.ConfigCache.GetAsync(base.CacheKey).ConfigureAwait(false);
-            config = await this.ConfigFetcher.FetchAsync(config).ConfigureAwait(false);
-            await this.ConfigCache.SetAsync(base.CacheKey, config).ConfigureAwait(false);
+            if (!IsOffline)
+            {
+                var config = await this.ConfigCache.GetAsync(base.CacheKey).ConfigureAwait(false);
+                config = await this.ConfigFetcher.FetchAsync(config).ConfigureAwait(false);
+                await this.ConfigCache.SetAsync(base.CacheKey, config).ConfigureAwait(false);
+            }
+            else
+            {
+                this.Log.OfflineModeWarning();
+            }
         }
     }
 }

--- a/src/ConfigCatClient/ConfigService/ManualPollConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/ManualPollConfigService.cs
@@ -6,8 +6,8 @@ namespace ConfigCat.Client.ConfigService
 {
     internal sealed class ManualPollConfigService : ConfigServiceBase, IConfigService
     {
-        internal ManualPollConfigService(IConfigFetcher configFetcher, CacheParameters cacheParameters, LoggerWrapper logger)
-            : base(configFetcher, cacheParameters, logger) { }
+        internal ManualPollConfigService(IConfigFetcher configFetcher, CacheParameters cacheParameters, LoggerWrapper logger, bool isOffline = false)
+            : base(configFetcher, cacheParameters, logger, isOffline) { }
 
         public ProjectConfig GetConfig()
         {

--- a/src/ConfigCatClient/ConfigService/NullConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/NullConfigService.cs
@@ -2,11 +2,11 @@
 
 namespace ConfigCat.Client.ConfigService
 {
-    internal sealed class EmptyConfigService : IConfigService
+    internal sealed class NullConfigService : IConfigService
     {
         private readonly LoggerWrapper log;
 
-        public EmptyConfigService(LoggerWrapper log)
+        public NullConfigService(LoggerWrapper log)
         {
             this.log = log;
         }

--- a/src/ConfigCatClient/Configuration/ConfigCatClientOptions.cs
+++ b/src/ConfigCatClient/Configuration/ConfigCatClientOptions.cs
@@ -6,9 +6,14 @@
     public class ConfigCatClientOptions : ConfigurationBase
     {
         /// <summary>
-        /// The polling mode.
+        /// The polling mode. Defaults to auto polling.
         /// </summary>
         public PollingMode PollingMode { get; set; } = PollingModes.AutoPoll();
+
+        /// <summary>
+        /// Indicates whether the client should be initialized to offline mode or not. Defaults to <see langword="false"/>.
+        /// </summary>
+        public bool Offline { get; set; }
 
         internal override void Validate()
         {

--- a/src/ConfigCatClient/IConfigCatClient.cs
+++ b/src/ConfigCatClient/IConfigCatClient.cs
@@ -112,5 +112,20 @@ namespace ConfigCat.Client
         /// Sets the default user to null.
         /// </summary>
         void ClearDefaultUser();
+
+        /// <summary>
+        /// True when the client is configured not to initiate HTTP requests, otherwise false.
+        /// </summary>
+        bool IsOffline { get; }
+
+        /// <summary>
+        /// Configures the client to allow HTTP requests.
+        /// </summary>
+        void SetOnline();
+
+        /// <summary>
+        /// Configures the client to not initiate HTTP requests and work only from its cache.
+        /// </summary>
+        void SetOffline();
     }
 }

--- a/src/ConfigCatClient/PollingModes.cs
+++ b/src/ConfigCatClient/PollingModes.cs
@@ -11,7 +11,7 @@ namespace ConfigCat.Client
         /// <summary>
         /// Constructs a new auto polling mode.
         /// </summary>
-        /// <param name="pollInterval">Configuration refresh period.</param>
+        /// <param name="pollInterval">Configuration refresh period. (Default value is 60 seconds.)</param>
         /// <param name="maxInitWaitTime">Maximum waiting time between initialization and the first config acquisition. (Default value is 5 seconds.)</param>
         /// <returns>The auto polling mode.</returns>
         public static AutoPoll AutoPoll(TimeSpan? pollInterval = null, TimeSpan? maxInitWaitTime = null) =>


### PR DESCRIPTION
### Describe the purpose of your pull request

* Adds `IConfigCatClient.IsOffline` property, `IConfigCatClient.SetOnline` and `IConfigCatClient.SetOffline` methods.
* Renames `EmptyConfigService` to `NullConfigService` for better naming as this class implements the [null object design pattern](https://sourcemaking.com/design_patterns/null_object). (This is just a suggestion though, we can scrap it if you disagree.)

It's also worth mentioning that in the current implementation the client goes into offline mode implicitly when gets disposed. This also prevents the user from making forced cache refreshes (`RefreshConfig`/`RefreshConfigAsync`) on a disposed client. If you don't think that this is a good design, let's discuss it.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
