### PR TITLE
LazyLoad and AutoPoll refresh logic improvements

### DIFF
--- a/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
+++ b/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
@@ -1503,7 +1503,7 @@ namespace ConfigCat.Client.Tests
                 return Task.FromResult(ProjectConfig.Empty);
             }
 
-            public Task RefreshConfigAsync()
+            public override Task RefreshConfigAsync()
             {
                 return Task.FromResult(0);
             }
@@ -1513,7 +1513,7 @@ namespace ConfigCat.Client.Tests
                 return ProjectConfig.Empty;
             }
 
-            public void RefreshConfig()
+            public override void RefreshConfig()
             { }
         }
     }

--- a/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
+++ b/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
@@ -522,6 +522,7 @@ namespace ConfigCat.Client.Tests
         {
             // Arrange
 
+            configServiceMock.Setup(m => m.GetConfig()).Returns(ProjectConfig.Empty);
             configServiceMock.Setup(m => m.GetConfigAsync()).ReturnsAsync(ProjectConfig.Empty);
             var o = new SettingsWithPreferences();
             configDeserializerMock

--- a/src/ConfigCatClient/Cache/InMemoryConfigCache.cs
+++ b/src/ConfigCatClient/Cache/InMemoryConfigCache.cs
@@ -5,7 +5,7 @@ namespace ConfigCat.Client
 {
     internal class InMemoryConfigCache : IConfigCatCache
     {
-        private ProjectConfig projectConfig;
+        private ProjectConfig projectConfig = ProjectConfig.Empty;
         private readonly ReaderWriterLockSlim lockSlim = new();
 
         /// <inheritdoc />

--- a/src/ConfigCatClient/Cache/InMemoryConfigCache.cs
+++ b/src/ConfigCatClient/Cache/InMemoryConfigCache.cs
@@ -6,13 +6,16 @@ namespace ConfigCat.Client
     internal class InMemoryConfigCache : IConfigCatCache
     {
         private ProjectConfig projectConfig = ProjectConfig.Empty;
-        private readonly ReaderWriterLockSlim lockSlim = new();
 
         /// <inheritdoc />
         public Task SetAsync(string key, ProjectConfig config)
         {
             this.Set(key, config);
+#if NET45
             return Task.FromResult(0);
+#else
+            return Task.CompletedTask;
+#endif
         }
 
         /// <inheritdoc />
@@ -22,31 +25,14 @@ namespace ConfigCat.Client
         /// <inheritdoc />
         public void Set(string key, ProjectConfig config)
         {
-            this.lockSlim.EnterWriteLock();
-
-            try
-            {
-                this.projectConfig = config;
-            }
-            finally
-            {
-                this.lockSlim.ExitWriteLock();
-            }
+            Interlocked.Exchange(ref this.projectConfig, config);
         }
 
         /// <inheritdoc />
         public ProjectConfig Get(string key)
         {
-            this.lockSlim.EnterReadLock();
-
-            try
-            {
-                return this.projectConfig;
-            }
-            finally
-            {
-                this.lockSlim.ExitReadLock();
-            }
+            // NOTE: Volatile.Read(ref this.projectConfig) would probably be sufficient but Interlocked.CompareExchange is the 100% safe way.
+            return Interlocked.CompareExchange(ref this.projectConfig, null, null);
         }
     }
 }

--- a/src/ConfigCatClient/ConfigService/ConfigServiceBase.cs
+++ b/src/ConfigCatClient/ConfigService/ConfigServiceBase.cs
@@ -92,15 +92,21 @@ namespace ConfigCat.Client.ConfigService
         {
             var newConfig = this.ConfigFetcher.Fetch(latestConfig);
 
-            if (!latestConfig.Equals(newConfig) && !newConfig.Equals(ProjectConfig.Empty))
+            var configContentHasChanged = !latestConfig.Equals(newConfig);
+            if ((configContentHasChanged || newConfig.TimeStamp > latestConfig.TimeStamp) && !newConfig.Equals(ProjectConfig.Empty))
             {
                 // TODO: This cast can be removed when we delete the obsolete IConfigCache interface.
                 ((IConfigCatCache)this.ConfigCache).Set(this.CacheKey, newConfig);
-                OnConfigChanged();
+
+                if (configContentHasChanged)
+                {
+                    OnConfigChanged();
+                }
+
                 return newConfig;
             }
 
-            return null;
+            return latestConfig;
         }
 
         public virtual async Task RefreshConfigAsync()
@@ -120,14 +126,20 @@ namespace ConfigCat.Client.ConfigService
         {
             var newConfig = await this.ConfigFetcher.FetchAsync(latestConfig).ConfigureAwait(false);
 
-            if (!latestConfig.Equals(newConfig) && !newConfig.Equals(ProjectConfig.Empty))
+            var configContentHasChanged = !latestConfig.Equals(newConfig);
+            if ((configContentHasChanged || newConfig.TimeStamp > latestConfig.TimeStamp) && !newConfig.Equals(ProjectConfig.Empty))
             {
                 await this.ConfigCache.SetAsync(this.CacheKey, newConfig).ConfigureAwait(false);
-                OnConfigChanged();
+
+                if (configContentHasChanged)
+                {
+                    OnConfigChanged();
+                }
+
                 return newConfig;
             }
 
-            return null;
+            return latestConfig;
         }
 
         protected virtual void OnConfigChanged()

--- a/src/ConfigCatClient/ConfigService/ConfigServiceBase.cs
+++ b/src/ConfigCatClient/ConfigService/ConfigServiceBase.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Threading.Tasks;
 using ConfigCat.Client.Cache;
+using ConfigCat.Client.Utils;
 
 namespace ConfigCat.Client.ConfigService
 {
@@ -11,7 +13,7 @@ namespace ConfigCat.Client.ConfigService
             Offline,
             Disposed,
         }
- 
+
         private Status status;
         private readonly object syncObj = new object();
 
@@ -62,6 +64,75 @@ namespace ConfigCat.Client.ConfigService
             }
 
             Dispose(true);
+        }
+
+        public virtual void RefreshConfig()
+        {
+            // check for the new cache interface until we remove the old IConfigCache.
+            if (this.ConfigCache is IConfigCatCache cache)
+            {
+                if (!IsOffline)
+                {
+                    var latestConfig = cache.Get(this.CacheKey);
+                    RefreshConfigCore(latestConfig);
+                }
+                else
+                {
+                    this.Log.OfflineModeWarning();
+                }
+
+                return;
+            }
+
+            // worst scenario, fallback to sync over async, delete when we enforce IConfigCatCache.
+            Syncer.Sync(this.RefreshConfigAsync);
+        }
+
+        protected ProjectConfig RefreshConfigCore(ProjectConfig latestConfig)
+        {
+            var newConfig = this.ConfigFetcher.Fetch(latestConfig);
+
+            if (!latestConfig.Equals(newConfig) && !newConfig.Equals(ProjectConfig.Empty))
+            {
+                // TODO: This cast can be removed when we delete the obsolete IConfigCache interface.
+                ((IConfigCatCache)this.ConfigCache).Set(this.CacheKey, newConfig);
+                OnConfigChanged();
+                return newConfig;
+            }
+
+            return null;
+        }
+
+        public virtual async Task RefreshConfigAsync()
+        {
+            if (!IsOffline)
+            {
+                var latestConfig = await this.ConfigCache.GetAsync(this.CacheKey).ConfigureAwait(false);
+                await RefreshConfigCoreAsync(latestConfig).ConfigureAwait(false);
+            }
+            else
+            {
+                this.Log.OfflineModeWarning();
+            }
+        }
+
+        protected async Task<ProjectConfig> RefreshConfigCoreAsync(ProjectConfig latestConfig)
+        {
+            var newConfig = await this.ConfigFetcher.FetchAsync(latestConfig).ConfigureAwait(false);
+
+            if (!latestConfig.Equals(newConfig) && !newConfig.Equals(ProjectConfig.Empty))
+            {
+                await this.ConfigCache.SetAsync(this.CacheKey, newConfig).ConfigureAwait(false);
+                OnConfigChanged();
+                return newConfig;
+            }
+
+            return null;
+        }
+
+        protected virtual void OnConfigChanged()
+        {
+            this.Log.Debug("config changed");
         }
 
         public bool IsOffline

--- a/src/ConfigCatClient/ConfigService/LazyLoadConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/LazyLoadConfigService.cs
@@ -31,7 +31,7 @@ namespace ConfigCat.Client.ConfigService
 
                     if (!IsOffline)
                     {
-                        return RefreshConfigCore(config) ?? config;
+                        return RefreshConfigCore(config);
                     }
                 }
 
@@ -55,7 +55,7 @@ namespace ConfigCat.Client.ConfigService
 
                 if (!IsOffline)
                 {
-                    return (await RefreshConfigCoreAsync(config).ConfigureAwait(false)) ?? config;
+                    return await RefreshConfigCoreAsync(config).ConfigureAwait(false);
                 }
             }
 

--- a/src/ConfigCatClient/ConfigService/ManualPollConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/ManualPollConfigService.cs
@@ -25,42 +25,5 @@ namespace ConfigCat.Client.ConfigService
         {
             return await this.ConfigCache.GetAsync(base.CacheKey).ConfigureAwait(false);
         }
-
-        public void RefreshConfig()
-        {
-            // check for the new cache interface until we remove the old IConfigCache.
-            if (this.ConfigCache is IConfigCatCache cache)
-            {
-                if (!IsOffline)
-                {
-                    var latestConfig = cache.Get(base.CacheKey);
-                    var newConfig = this.ConfigFetcher.Fetch(latestConfig);
-                    cache.Set(base.CacheKey, newConfig);
-                }
-                else
-                {
-                    this.Log.OfflineModeWarning();
-                }
-
-                return;
-            }
-
-            // worst scenario, fallback to sync over async, delete when we enforce IConfigCatCache.
-            Syncer.Sync(this.RefreshConfigAsync);
-        }
-
-        public async Task RefreshConfigAsync()
-        {
-            if (!IsOffline)
-            {
-                var config = await this.ConfigCache.GetAsync(base.CacheKey).ConfigureAwait(false);
-                config = await this.ConfigFetcher.FetchAsync(config).ConfigureAwait(false);
-                await this.ConfigCache.SetAsync(base.CacheKey, config).ConfigureAwait(false);
-            }
-            else
-            {
-                this.Log.OfflineModeWarning();
-            }
-        }
     }
 }

--- a/src/ConfigCatClient/HttpConfigFetcher.cs
+++ b/src/ConfigCatClient/HttpConfigFetcher.cs
@@ -93,13 +93,11 @@ namespace ConfigCat.Client
                     };
                 }
                 else
+                {
                     switch (response.StatusCode)
                     {
                         case HttpStatusCode.NotModified:
-                            return lastConfig with 
-                            {
-                                TimeStamp = DateTime.UtcNow
-                            };
+                            break;
                         case HttpStatusCode.NotFound:
                             this.log.Error("Double-check your SDK Key at https://app.configcat.com/sdkkey");
                             break;
@@ -107,6 +105,14 @@ namespace ConfigCat.Client
                             this.ReInitializeHttpClient();
                             break;
                     }
+
+                    // We update the timestamp even if a status code other than 304 NotModified is returned
+                    // for extra protection against flooding.
+                    return lastConfig with
+                    {
+                        TimeStamp = DateTime.UtcNow
+                    };
+                }
             }
             catch (OperationCanceledException) when (this.cancellationTokenSource.IsCancellationRequested)
             {

--- a/src/ConfigCatClient/HttpConfigFetcher.cs
+++ b/src/ConfigCatClient/HttpConfigFetcher.cs
@@ -59,8 +59,6 @@ namespace ConfigCat.Client
 
         private async ValueTask<ProjectConfig> FetchInternalAsync(ProjectConfig lastConfig, bool isAsync)
         {
-            var newConfig = lastConfig;
-
             try
             {
 #if NET5_0_OR_GREATER
@@ -87,8 +85,12 @@ namespace ConfigCat.Client
 
                 if (response is { IsSuccessStatusCode: true })
                 {
-                    newConfig.HttpETag = response.Headers.ETag?.Tag;
-                    newConfig.JsonString = fetchResult.Item2;
+                    return new ProjectConfig
+                    {
+                        HttpETag = response.Headers.ETag?.Tag,
+                        JsonString = fetchResult.Item2,
+                        TimeStamp = DateTime.UtcNow
+                    };
                 }
                 else
                     switch (response.StatusCode)
@@ -123,8 +125,7 @@ namespace ConfigCat.Client
                 this.ReInitializeHttpClient();
             }
 
-            newConfig.TimeStamp = DateTime.UtcNow;
-            return newConfig;
+            return lastConfig with { TimeStamp = DateTime.UtcNow };
         }
 
         private async ValueTask<Tuple<HttpResponseMessage, string>> FetchRequest(ProjectConfig lastConfig,

--- a/src/ConfigCatClient/ProjectConfig.cs
+++ b/src/ConfigCatClient/ProjectConfig.cs
@@ -9,12 +9,12 @@ namespace ConfigCat.Client
     public record class ProjectConfig : IEquatable<ProjectConfig>
     {
         /// <summary>
-        ///  A read-only instance of the ProjectConfig structure whose value is empty.
+        ///  A read-only instance of the <see cref="ProjectConfig"/> record whose value is empty.
         /// </summary>
         public static readonly ProjectConfig Empty = new(null, DateTime.MinValue, null);
 
         /// <summary>
-        /// ProjectConfig in json string format
+        /// The <see cref="ProjectConfig"/> in json string format
         /// </summary>
         public string JsonString
         {
@@ -27,7 +27,7 @@ namespace ConfigCat.Client
         }
 
         /// <summary>
-        /// TimeStamp of the ProjectConfig's acquire
+        /// Time of <see cref="ProjectConfig"/>'s successful download
         /// </summary>
         public DateTime TimeStamp
         {
@@ -40,7 +40,7 @@ namespace ConfigCat.Client
         }
 
         /// <summary>
-        /// Http entity tag of the ProjectConfig
+        /// Http entity tag of the <see cref="ProjectConfig"/>
         /// </summary>
         public string HttpETag
         {
@@ -92,6 +92,12 @@ namespace ConfigCat.Client
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(HttpETag);
             hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(JsonString);
             return hashCode;
+        }
+
+        internal bool IsExpired(TimeSpan expiration, out bool isEmpty)
+        {
+            isEmpty = Equals(Empty);
+            return isEmpty || TimeStamp + expiration < DateTime.UtcNow;
         }
     }
 }

--- a/src/ConfigCatClient/ProjectConfig.cs
+++ b/src/ConfigCatClient/ProjectConfig.cs
@@ -6,7 +6,7 @@ namespace ConfigCat.Client
     /// <summary>
     /// ConfigCat ProjectConfig definition
     /// </summary>
-    public struct ProjectConfig : IEquatable<ProjectConfig>
+    public record class ProjectConfig : IEquatable<ProjectConfig>
     {
         /// <summary>
         ///  A read-only instance of the ProjectConfig structure whose value is empty.
@@ -16,52 +16,82 @@ namespace ConfigCat.Client
         /// <summary>
         /// ProjectConfig in json string format
         /// </summary>
-        public string JsonString { get; set; }
+        public string JsonString
+        {
+            get;
+#if NET5_0_OR_GREATER
+            init;
+#else
+            internal set;
+#endif
+        }
 
         /// <summary>
         /// TimeStamp of the ProjectConfig's acquire
         /// </summary>
-        public DateTime TimeStamp { get; set; }
+        public DateTime TimeStamp
+        {
+            get;
+#if NET5_0_OR_GREATER
+            init;
+#else
+            internal set;
+#endif
+        }
 
         /// <summary>
         /// Http entity tag of the ProjectConfig
         /// </summary>
-        public string HttpETag { get; set; }
-
-        internal ProjectConfig(string jsonString, DateTime timeStamp, string httpETag)
+        public string HttpETag
         {
-            this.JsonString = jsonString;
-            this.TimeStamp = timeStamp;
-            this.HttpETag = httpETag;
+            get;
+#if NET5_0_OR_GREATER
+            init;
+#else
+            internal set;
+#endif
         }
 
-        /// <inheritdoc />
-        public override bool Equals(object obj) => obj is ProjectConfig config && this.Equals(config);
+        /// <summary>
+        /// Creates an instance of <see cref="ProjectConfig"/>.
+        /// </summary>
+        public ProjectConfig() { }
+
+        /// <summary>
+        /// Creates an instance of <see cref="ProjectConfig"/>.
+        /// </summary>
+        /// <param name="jsonString">ProjectConfig in json string format.</param>
+        /// <param name="timeStamp">TimeStamp of the ProjectConfig's acquire.</param>
+        /// <param name="httpETag">Http entity tag of the ProjectConfig.</param>
+        public ProjectConfig(string jsonString, DateTime timeStamp, string httpETag)
+        {
+            JsonString = jsonString;
+            TimeStamp = timeStamp;
+            HttpETag = httpETag;
+        }
 
         /// <summary>
         /// Determines whether this instance and another specified ProjectConfig struct have the same value.
         /// </summary>
         /// <param name="other">The ProjectConfig to compare to this instance.</param>
         /// <returns>
-        /// True if the value of the value parameter is the same as the value of this instance otherwise, false.         
+        /// True if the value of the value parameter is the same as the value of this instance otherwise, false.
         /// </returns>
-        public bool Equals(ProjectConfig other)
+        public virtual bool Equals(ProjectConfig other)
         {
-            return this.HttpETag == other.HttpETag && this.JsonString == other.JsonString;
+            return
+                other is not null &&
+                HttpETag == other.HttpETag &&
+                JsonString == other.JsonString;
         }
 
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            unchecked
-            {
-                var hashCode = 1098790081;
-                hashCode = hashCode * -1521134295 + base.GetHashCode();
-                hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(JsonString);
-                hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(HttpETag);
-
-                return hashCode; 
-            }
+            int hashCode = 1098790081;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(HttpETag);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(JsonString);
+            return hashCode;
         }
     }
 }


### PR DESCRIPTION
### Describe the purpose of your pull request

* Improves refresh logic of `AutoPollConfigService` and `LazyLoadConfigService` to take the cache download time into account to fetch the config only if cached config is unavailable or stale.
* Also does some cleanup around `*ConfigService` classes.

Breaking changes:
* Changes `ProjectConfig` to reference type with value equality (record)
* Slightly changes the behavior of `ProjectConfig.TimeStamp` (only updated when ~download succeeds~ communication with the CDN servers succeeds, regardless of the returned status code)

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
