### PR TITLE
Fixes subtle bug in the case of multiple Dispose calls

### DIFF
--- a/src/ConfigCat.Client.Tests/ConfigCatClientCacheTests.cs
+++ b/src/ConfigCat.Client.Tests/ConfigCatClientCacheTests.cs
@@ -112,7 +112,7 @@ namespace ConfigCat.Client.Tests
 
             // Act
 
-            var success = cache.Remove(sdkKey, out var removedInstance);
+            var success = cache.Remove(sdkKey, instanceToRemove: client1);
 
             // Assert
 
@@ -122,8 +122,6 @@ namespace ConfigCat.Client.Tests
 
             Assert.IsNotNull(client1);
             Assert.IsFalse(instanceAlreadyCreated1);
-
-            Assert.AreSame(client1, removedInstance);
         }
 
         [TestMethod]
@@ -157,7 +155,7 @@ namespace ConfigCat.Client.Tests
 
             // Act
 
-            var success = cache.Remove(sdkKey, out _);
+            var success = cache.Remove(sdkKey, instanceToRemove: null);
 
             // Assert
 
@@ -180,7 +178,7 @@ namespace ConfigCat.Client.Tests
 
             // Act
 
-            var success = cache.Remove(sdkKey, out _);
+            var success = cache.Remove(sdkKey, instanceToRemove: null);
 
             // Assert
 

--- a/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
+++ b/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
@@ -1291,6 +1291,43 @@ namespace ConfigCat.Client.Tests
 
         [TestMethod]
         [DoNotParallelize]
+        public void Dispose_CanRemoveCurrentCachedInstanceOnly()
+        {
+            // Arrange
+
+            var client1 = ConfigCatClient.Get("test", options => options.PollingMode = PollingModes.ManualPoll);
+
+            // Act
+
+            var instanceCount1 = ConfigCatClient.Instances.Count;
+
+            client1.Dispose();
+
+            var instanceCount2 = ConfigCatClient.Instances.Count;
+
+            var client2 = ConfigCatClient.Get("test", options => options.PollingMode = PollingModes.ManualPoll);
+
+            var instanceCount3 = ConfigCatClient.Instances.Count;
+
+            client1.Dispose();
+
+            var instanceCount4 = ConfigCatClient.Instances.Count;
+
+            client2.Dispose();
+
+            var instanceCount5 = ConfigCatClient.Instances.Count;
+
+            // Assert
+
+            Assert.AreEqual(1, instanceCount1);
+            Assert.AreEqual(0, instanceCount2);
+            Assert.AreEqual(1, instanceCount3);
+            Assert.AreEqual(1, instanceCount4);
+            Assert.AreEqual(0, instanceCount5);
+        }
+
+        [TestMethod]
+        [DoNotParallelize]
         public void DisposeAll_CachedInstancesRemoved()
         {
             // Arrange

--- a/src/ConfigCatClient/ConfigCatClient.cs
+++ b/src/ConfigCatClient/ConfigCatClient.cs
@@ -457,7 +457,7 @@ namespace ConfigCat.Client
 
             if (!this.isUncached && this.sdkKey is not null)
             {
-                Instances.Remove(this.sdkKey, out _);
+                Instances.Remove(this.sdkKey, instanceToRemove: this);
             }
 
             Dispose(disposing: false);
@@ -515,7 +515,7 @@ namespace ConfigCat.Client
         {
             if (!this.isUncached)
             {
-                Instances.Remove(this.sdkKey, out _);
+                Instances.Remove(this.sdkKey, instanceToRemove: this);
             }
 
             Dispose(disposing: true);

--- a/src/ConfigCatClient/ConfigCatClientCache.cs
+++ b/src/ConfigCatClient/ConfigCatClientCache.cs
@@ -45,21 +45,18 @@ namespace ConfigCat.Client
             }
         }
 
-        public bool Remove(string sdkKey, out ConfigCatClient removedInstance)
+        public bool Remove(string sdkKey, ConfigCatClient instanceToRemove)
         {
             lock (instances)
             {
                 if (instances.TryGetValue(sdkKey, out var weakRef))
                 {
-                    instances.Remove(sdkKey);
-                    if (weakRef.TryGetTarget(out removedInstance))
+                    var instanceIsAvailable = weakRef.TryGetTarget(out var instance);
+                    if (!instanceIsAvailable || ReferenceEquals(instance, instanceToRemove))
                     {
-                        return true;
+                        instances.Remove(sdkKey);
+                        return instanceIsAvailable;
                     }
-                }
-                else
-                {
-                    removedInstance = default;
                 }
 
                 return false;


### PR DESCRIPTION
### Describe the purpose of your pull request

Consider the following pattern:

```csharp
// 1. Creates a new instance of ConfigCatClient under the hood
var client1 = ConfigCatClient.Get("<KEY>");

// 2. Removes the previously created instance from the client cache
client1.Dispose();

// 3. Creates another instance of ConfigCatClient with the *same* key
var client2 = ConfigCatClient.Get("<KEY>");

// 4. Dispose can be called multiple times (it's not prohibited) but it should have no effect.
// However, if the Dispose logic just blindly removes the current cached instance by key,
// it will remove the other instance (client2), which would mess up the logic of shared instances.
// That is, we need to safeguard against this by making Dispose truly idempotent!
client1.Dispose();
```

A possible way of fixing this is presented in this PR. Another solution could be a `disposed` flag.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
