### PR TITLE
Track the changes of the source override dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 7.2.0
+
+- Introduced a new local dictionary override factory method:
+  ```csharp
+  FlagOverrides LocalDictionary(IDictionary<string, object> dictionary, bool watchChanges, OverrideBehaviour overrideBehaviour)
+  ``` 
+  Where the `watchChanges` parameter indicates whether the SDK should rebuild the overrides upon each read to keep track of the source dictionary's changes.
+
 ### 7.1.0
 
 - Add new evaluation methods `GetAllValueDetails`/`GetAllValueDetailsAsync`.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  build_version: 7.1.0
+  build_version: 7.2.0
 version: $(build_version)-{build}
 image: Visual Studio 2022
 configuration: Release

--- a/src/ConfigCat.Client.Tests/OverrideTests.cs
+++ b/src/ConfigCat.Client.Tests/OverrideTests.cs
@@ -304,6 +304,54 @@ namespace ConfigCat.Client.Tests
         }
 
         [TestMethod]
+        public void LocalOnly_Watch()
+        {
+            var dict = new Dictionary<string, object>
+            {
+                {"fakeKey", "test1"},
+            };
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            using var client = new ConfigCatClient(options =>
+            {
+                options.SdkKey = "localhost";
+                options.FlagOverrides = FlagOverrides.LocalDictionary(dict, true, OverrideBehaviour.LocalOnly);
+                options.PollingMode = PollingModes.ManualPoll;
+            });
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            Assert.AreEqual("test1", client.GetValue("fakeKey", string.Empty));
+
+            dict["fakeKey"] = "test2";
+
+            Assert.AreEqual("test2", client.GetValue("fakeKey", string.Empty));
+        }
+
+        [TestMethod]
+        public async Task LocalOnly_Async_Watch()
+        {
+            var dict = new Dictionary<string, object>
+            {
+                {"fakeKey", "test1"},
+            };
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            using var client = new ConfigCatClient(options =>
+            {
+                options.SdkKey = "localhost";
+                options.FlagOverrides = FlagOverrides.LocalDictionary(dict, true, OverrideBehaviour.LocalOnly);
+                options.PollingMode = PollingModes.ManualPoll;
+            });
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            Assert.AreEqual("test1", await client.GetValueAsync("fakeKey", string.Empty));
+
+            dict["fakeKey"] = "test2";
+
+            Assert.AreEqual("test2", await client.GetValueAsync("fakeKey", string.Empty));
+        }
+
+        [TestMethod]
         public async Task LocalOnly_Async()
         {
             var dict = new Dictionary<string, object>

--- a/src/ConfigCatClient/Override/FlagOverrides.cs
+++ b/src/ConfigCatClient/Override/FlagOverrides.cs
@@ -21,9 +21,10 @@ namespace ConfigCat.Client
             this.OverrideBehaviour = overrideBehaviour;
         }
 
-        private FlagOverrides(IDictionary<string, object> dictionary, OverrideBehaviour overrideBehaviour)
+        private FlagOverrides(IDictionary<string, object> dictionary, bool watchChanges, OverrideBehaviour overrideBehaviour)
         {
             this.dictionary = dictionary;
+            this.autoReload = watchChanges;
             this.OverrideBehaviour = overrideBehaviour;
         }
 
@@ -37,7 +38,7 @@ namespace ConfigCat.Client
         internal IOverrideDataSource BuildDataSource(LoggerWrapper logger)
         {
             if (this.dictionary != null)
-                return new LocalDictionaryDataSource(this.dictionary);
+                return new LocalDictionaryDataSource(this.dictionary, this.autoReload);
 
             if (this.filePath != null)
                 return new LocalFileDataSource(this.filePath, this.autoReload, logger);
@@ -53,7 +54,7 @@ namespace ConfigCat.Client
         /// <param name="overrideBehaviour">the override behaviour. It can be used to set preference on whether the local values should override the remote values, or use local values only when a remote value doesn't exist, or use it for local only mode.</param>
         /// <returns>The override descriptor.</returns>
         public static FlagOverrides LocalFile(string filePath, bool autoReload, OverrideBehaviour overrideBehaviour) => 
-            new FlagOverrides(filePath, autoReload, overrideBehaviour);
+            new(filePath, autoReload, overrideBehaviour);
 
         /// <summary>
         /// Creates an override descriptor that uses a dictionary data source.
@@ -62,6 +63,16 @@ namespace ConfigCat.Client
         /// <param name="overrideBehaviour">the override behaviour. It can be used to set preference on whether the local values should override the remote values, or use local values only when a remote value doesn't exist, or use it for local only mode.</param>
         /// <returns>The override descriptor.</returns>
         public static FlagOverrides LocalDictionary(IDictionary<string, object> dictionary, OverrideBehaviour overrideBehaviour) =>
-            new FlagOverrides(dictionary, overrideBehaviour);
+            new(dictionary, false, overrideBehaviour);
+
+        /// <summary>
+        /// Creates an override descriptor that uses a dictionary data source.
+        /// </summary>
+        /// <param name="dictionary">Dictionary that contains the overrides.</param>
+        /// <param name="watchChanges">Indicates whether the SDK should track the input dictionary for changes.</param>
+        /// <param name="overrideBehaviour">the override behaviour. It can be used to set preference on whether the local values should override the remote values, or use local values only when a remote value doesn't exist, or use it for local only mode.</param>
+        /// <returns>The override descriptor.</returns>
+        public static FlagOverrides LocalDictionary(IDictionary<string, object> dictionary, bool watchChanges, OverrideBehaviour overrideBehaviour) =>
+            new(dictionary, watchChanges, overrideBehaviour);
     }
 }

--- a/src/ConfigCatClient/Override/LocalDictionaryDataSource.cs
+++ b/src/ConfigCatClient/Override/LocalDictionaryDataSource.cs
@@ -8,17 +8,25 @@ namespace ConfigCat.Client.Override
 {
     internal sealed class LocalDictionaryDataSource : IOverrideDataSource
     {
-        private readonly IDictionary<string, Setting> settings;
+        private readonly IDictionary<string, Setting> initialSettings;
+        private readonly IDictionary<string, object> overrideValues;
+        private readonly bool watchChanges;
 
-        public LocalDictionaryDataSource(IDictionary<string, object> overrideValues)
+        public LocalDictionaryDataSource(IDictionary<string, object> overrideValues, bool watchChanges)
         {
-            this.settings = overrideValues.ToDictionary(kv => kv.Key, kv => kv.Value.ToSetting());
+            this.initialSettings = overrideValues.ToDictionary(kv => kv.Key, kv => kv.Value.ToSetting());
+            this.overrideValues = overrideValues;
+            this.watchChanges = watchChanges;
         }
 
-        public IDictionary<string, Setting> GetOverrides() => this.settings;
+        public IDictionary<string, Setting> GetOverrides() => GetSettingsFromSource();
 
-        public Task<IDictionary<string, Setting>> GetOverridesAsync() => Task.FromResult(this.settings);
+        public Task<IDictionary<string, Setting>> GetOverridesAsync() => Task.FromResult(GetSettingsFromSource());
 
         public void Dispose() { /* no need to dispose anything */ }
+
+        private IDictionary<string, Setting> GetSettingsFromSource() => watchChanges
+            ? overrideValues.ToDictionary(kv => kv.Key, kv => kv.Value.ToSetting())
+            : this.initialSettings;
     }
 }

--- a/src/ConfigCatClient/Override/LocalDictionaryDataSource.cs
+++ b/src/ConfigCatClient/Override/LocalDictionaryDataSource.cs
@@ -10,13 +10,14 @@ namespace ConfigCat.Client.Override
     {
         private readonly IDictionary<string, Setting> initialSettings;
         private readonly IDictionary<string, object> overrideValues;
-        private readonly bool watchChanges;
 
         public LocalDictionaryDataSource(IDictionary<string, object> overrideValues, bool watchChanges)
         {
             this.initialSettings = overrideValues.ToDictionary(kv => kv.Key, kv => kv.Value.ToSetting());
-            this.overrideValues = overrideValues;
-            this.watchChanges = watchChanges;
+            if (watchChanges)
+            {
+                this.overrideValues = overrideValues;
+            }
         }
 
         public IDictionary<string, Setting> GetOverrides() => GetSettingsFromSource();
@@ -25,7 +26,7 @@ namespace ConfigCat.Client.Override
 
         public void Dispose() { /* no need to dispose anything */ }
 
-        private IDictionary<string, Setting> GetSettingsFromSource() => watchChanges
+        private IDictionary<string, Setting> GetSettingsFromSource() => overrideValues != null
             ? overrideValues.ToDictionary(kv => kv.Key, kv => kv.Value.ToSetting())
             : this.initialSettings;
     }


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR contains the following:
- Introduces a new local dictionary override factory method:
  ```csharp
  FlagOverrides LocalDictionary(IDictionary<string, object> dictionary, bool watchChanges, OverrideBehaviour overrideBehaviour)
  ``` 
  Where the `watchChanges` parameter indicates whether the SDK should rebuild the overrides upon each read to keep track of the source dictionary's changes.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
