### PR TITLE
Fix config fetcher-related error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   FlagOverrides LocalDictionary(IDictionary<string, object> dictionary, bool watchChanges, OverrideBehaviour overrideBehaviour)
   ``` 
   Where the `watchChanges` parameter indicates whether the SDK should rebuild the overrides upon each read to keep track of the source dictionary's changes.
+- Fix config fetcher-related error logging to include exception in the log if any.
 
 ### 7.1.0
 

--- a/src/ConfigCatClient/HttpConfigFetcher.cs
+++ b/src/ConfigCatClient/HttpConfigFetcher.cs
@@ -165,7 +165,7 @@ namespace ConfigCat.Client
                 errorException = ex;
             }
 
-            this.log.Error(errorMessage);
+            this.log.Error(errorMessage, errorException);
             this.ReInitializeHttpClient();
             return FetchResult.Failure(lastConfig, errorMessage, errorException);
         }


### PR DESCRIPTION
### Describe the purpose of your pull request

Fixes error logging in `HttpConfigFetcher.FetchInternalAsync` to include exception in the log if any (to make the behavior consistent with other SDKs.)

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
