### PR TITLE
Fix validation of polling mode intervals

### DIFF
--- a/src/ConfigCat.Client.Tests/ConfigServiceTests.cs
+++ b/src/ConfigCat.Client.Tests/ConfigServiceTests.cs
@@ -306,7 +306,7 @@ public class ConfigServiceTests
             .Callback(() => Interlocked.Increment(ref counter))
             .ReturnsAsync(FetchResult.Success(this.cachedPc));
 
-        var config = PollingModes.AutoPoll(TimeSpan.FromSeconds(0.2d), TimeSpan.FromSeconds(0));
+        var config = PollingModes.AutoPoll(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(0));
         using var service = new AutoPollConfigService(config,
             this.fetcherMock.Object,
             new CacheParameters(this.cacheMock.Object, cacheKey: ""),
@@ -314,13 +314,13 @@ public class ConfigServiceTests
             startTimer: false);
 
         // Act
-        await Task.Delay(TimeSpan.FromSeconds(1));
+        await Task.Delay(TimeSpan.FromSeconds(2));
         e1 = Interlocked.Read(ref counter);
         service.Dispose();
 
         // Assert
 
-        await Task.Delay(TimeSpan.FromSeconds(1));
+        await Task.Delay(TimeSpan.FromSeconds(2));
         e2 = Interlocked.Read(ref counter);
         Console.WriteLine(e2 - e1);
         Assert.IsTrue(e2 - e1 <= 1);
@@ -343,7 +343,7 @@ public class ConfigServiceTests
             .Callback(() => Interlocked.Increment(ref counter))
             .ReturnsAsync(FetchResult.Success(this.cachedPc));
 
-        var config = PollingModes.AutoPoll(TimeSpan.FromSeconds(0.2d), TimeSpan.FromSeconds(0));
+        var config = PollingModes.AutoPoll(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(0));
         using var service = new AutoPollConfigService(config,
             this.fetcherMock.Object,
             new CacheParameters(this.cacheMock.Object, cacheKey: null!),
@@ -351,7 +351,7 @@ public class ConfigServiceTests
             startTimer: false);
 
         // Act
-        await Task.Delay(TimeSpan.FromSeconds(1));
+        await Task.Delay(TimeSpan.FromSeconds(2));
         e1 = Interlocked.Read(ref counter);
         service.Dispose();
 

--- a/src/ConfigCat.Client.Tests/ConfigurationTests.cs
+++ b/src/ConfigCat.Client.Tests/ConfigurationTests.cs
@@ -1,0 +1,78 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ConfigCat.Client.Tests;
+
+[TestClass]
+public class ConfigurationTests
+{
+    [DataRow(-1L, false)]
+    [DataRow(0L, false)]
+    [DataRow(999L, false)]
+    [DataRow(1000L, true)]
+    [DataRow(int.MaxValue, true)]
+    [DataRow(int.MaxValue + 1L, false)]
+    [DataTestMethod]
+    public void AutoPoll_PollIntervalRangeValidation_Works(long pollIntervalMs, bool isValid)
+    {
+        var pollInterval = TimeSpan.FromMilliseconds(pollIntervalMs);
+        Action action = () => PollingModes.AutoPoll(pollInterval: pollInterval);
+
+        if (isValid)
+        {
+            action();
+        }
+        else
+        {
+            var ex = Assert.ThrowsException<ArgumentOutOfRangeException>(action);
+            Assert.AreEqual(nameof(pollInterval), ex.ParamName);
+            Assert.AreEqual(pollInterval, ex.ActualValue);
+        }
+    }
+
+    [DataRow(-1L, true)]
+    [DataRow(0L, true)]
+    [DataRow(int.MaxValue, true)]
+    [DataRow(int.MaxValue + 1L, false)]
+    [DataTestMethod]
+    public void AutoPoll_MaxInitWaitTimeRangeValidation_Works(long maxInitWaitTimeMs, bool isValid)
+    {
+        var maxInitWaitTime = TimeSpan.FromMilliseconds(maxInitWaitTimeMs);
+        Action action = () => PollingModes.AutoPoll(maxInitWaitTime: maxInitWaitTime);
+
+        if (isValid)
+        {
+            action();
+        }
+        else
+        {
+            var ex = Assert.ThrowsException<ArgumentOutOfRangeException>(action);
+            Assert.AreEqual(nameof(maxInitWaitTime), ex.ParamName);
+            Assert.AreEqual(maxInitWaitTime, ex.ActualValue);
+        }
+    }
+
+    [DataRow(-1L, false)]
+    [DataRow(0L, false)]
+    [DataRow(999L, false)]
+    [DataRow(1000L, true)]
+    [DataRow(int.MaxValue * 1000L, true)]
+    [DataRow(int.MaxValue * 1000L + 1L, false)]
+    [DataTestMethod]
+    public void LazyLoad_CacheTimeToLiveRangeValidation_Works(long cacheTimeToLiveMs, bool isValid)
+    {
+        var cacheTimeToLive = TimeSpan.FromMilliseconds(cacheTimeToLiveMs);
+        Action action = () => PollingModes.LazyLoad(cacheTimeToLive: cacheTimeToLive);
+
+        if (isValid)
+        {
+            action();
+        }
+        else
+        {
+            var ex = Assert.ThrowsException<ArgumentOutOfRangeException>(action);
+            Assert.AreEqual(nameof(cacheTimeToLive), ex.ParamName);
+            Assert.AreEqual(cacheTimeToLive, ex.ActualValue);
+        }
+    }
+}

--- a/src/ConfigCatClient/ConfigService/AutoPollConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/AutoPollConfigService.cs
@@ -8,7 +8,8 @@ namespace ConfigCat.Client.ConfigService;
 
 internal sealed class AutoPollConfigService : ConfigServiceBase, IConfigService
 {
-    private readonly AutoPoll configuration;
+    private readonly TimeSpan pollInterval;
+    private readonly TimeSpan maxInitWaitTime;
     private readonly CancellationTokenSource initializationCancellationTokenSource = new(); // used for signalling initialization
     private CancellationTokenSource? timerCancellationTokenSource = new(); // used for signalling background work to stop
 
@@ -31,21 +32,22 @@ internal sealed class AutoPollConfigService : ConfigServiceBase, IConfigService
         bool isOffline = false,
         Hooks? hooks = null) : base(configFetcher, cacheParameters, logger, isOffline, hooks)
     {
-        this.configuration = configuration;
+        this.pollInterval = configuration.PollInterval;
+        this.maxInitWaitTime = configuration.MaxInitWaitTime >= TimeSpan.Zero ? configuration.MaxInitWaitTime : Timeout.InfiniteTimeSpan;
 
         this.initializationCancellationTokenSource.Token.Register(this.Hooks.RaiseClientReady, useSynchronizationContext: false);
         if (configuration.MaxInitWaitTime > TimeSpan.Zero)
         {
             this.initializationCancellationTokenSource.CancelAfter(configuration.MaxInitWaitTime);
         }
-        else
+        else if (configuration.MaxInitWaitTime == TimeSpan.Zero)
         {
             this.initializationCancellationTokenSource.Cancel();
         }
 
         if (!isOffline && startTimer)
         {
-            StartScheduler(configuration.PollInterval);
+            StartScheduler();
         }
     }
 
@@ -93,7 +95,7 @@ internal sealed class AutoPollConfigService : ConfigServiceBase, IConfigService
     internal bool WaitForInitialization()
     {
         // An infinite timeout would also work but we limit waiting to MaxInitWaitTime for maximum safety.
-        return this.initializationCancellationTokenSource.Token.WaitHandle.WaitOne(this.configuration.MaxInitWaitTime);
+        return this.initializationCancellationTokenSource.Token.WaitHandle.WaitOne(this.maxInitWaitTime);
     }
 
     internal async Task<bool> WaitForInitializationAsync(CancellationToken cancellationToken = default)
@@ -101,7 +103,7 @@ internal sealed class AutoPollConfigService : ConfigServiceBase, IConfigService
         try
         {
             // An infinite timeout would also work but we limit waiting to MaxInitWaitTime for maximum safety.
-            await Task.Delay(this.configuration.MaxInitWaitTime, this.initializationCancellationTokenSource.Token)
+            await Task.Delay(this.maxInitWaitTime, this.initializationCancellationTokenSource.Token)
                 .WaitAsync(cancellationToken).ConfigureAwait(false);
 
             return false;
@@ -117,7 +119,7 @@ internal sealed class AutoPollConfigService : ConfigServiceBase, IConfigService
         if (!IsOffline && !IsInitialized)
         {
             var cacheConfig = this.ConfigCache.Get(base.CacheKey);
-            if (!cacheConfig.IsExpired(expiration: this.configuration.PollInterval, out _))
+            if (!cacheConfig.IsExpired(expiration: this.pollInterval, out _))
             {
                 return cacheConfig;
             }
@@ -133,7 +135,7 @@ internal sealed class AutoPollConfigService : ConfigServiceBase, IConfigService
         if (!IsOffline && !IsInitialized)
         {
             var cacheConfig = await this.ConfigCache.GetAsync(base.CacheKey, cancellationToken).ConfigureAwait(false);
-            if (!cacheConfig.IsExpired(expiration: this.configuration.PollInterval, out _))
+            if (!cacheConfig.IsExpired(expiration: this.pollInterval, out _))
             {
                 return cacheConfig;
             }
@@ -152,7 +154,7 @@ internal sealed class AutoPollConfigService : ConfigServiceBase, IConfigService
 
     protected override void SetOnlineCoreSynchronized()
     {
-        StartScheduler(this.configuration.PollInterval);
+        StartScheduler();
     }
 
     protected override void SetOfflineCoreSynchronized()
@@ -162,7 +164,7 @@ internal sealed class AutoPollConfigService : ConfigServiceBase, IConfigService
         this.timerCancellationTokenSource = new CancellationTokenSource();
     }
 
-    private void StartScheduler(TimeSpan interval)
+    private void StartScheduler()
     {
         Task.Run(async () =>
         {
@@ -173,10 +175,10 @@ internal sealed class AutoPollConfigService : ConfigServiceBase, IConfigService
             {
                 try
                 {
-                    var scheduledNextTime = DateTime.UtcNow.Add(interval);
+                    var scheduledNextTime = DateTime.UtcNow.Add(this.pollInterval);
                     try
                     {
-                        await PollCoreAsync(isFirstIteration, interval, cancellationToken).ConfigureAwait(false);
+                        await PollCoreAsync(isFirstIteration, cancellationToken).ConfigureAwait(false);
                     }
                     catch (Exception ex) when (ex is not OperationCanceledException)
                     {
@@ -203,12 +205,12 @@ internal sealed class AutoPollConfigService : ConfigServiceBase, IConfigService
         });
     }
 
-    private async Task PollCoreAsync(bool isFirstIteration, TimeSpan interval, CancellationToken cancellationToken)
+    private async Task PollCoreAsync(bool isFirstIteration, CancellationToken cancellationToken)
     {
         if (isFirstIteration)
         {
             var latestConfig = await this.ConfigCache.GetAsync(base.CacheKey, cancellationToken).ConfigureAwait(false);
-            if (latestConfig.IsExpired(expiration: interval, out _))
+            if (latestConfig.IsExpired(expiration: this.pollInterval, out _))
             {
                 if (!IsOffline)
                 {

--- a/src/ConfigCatClient/Configuration/PollingMode.cs
+++ b/src/ConfigCatClient/Configuration/PollingMode.cs
@@ -25,17 +25,22 @@ public class AutoPoll : PollingMode
     public TimeSpan PollInterval { get; }
 
     /// <summary>
-    /// Maximum waiting time between initialization and the first config acquisition. (Default value is 5 seconds.)
+    /// Maximum waiting time between initialization and the first config acquisition.
     /// </summary>
     public TimeSpan MaxInitWaitTime { get; }
 
     internal AutoPoll(TimeSpan pollInterval, TimeSpan maxInitWaitTime)
     {
-        PollInterval = pollInterval > TimeSpan.Zero
-            ? pollInterval
-            : throw new ArgumentOutOfRangeException(nameof(pollInterval), "Value must be greater than zero.");
+        var minPollInterval = TimeSpan.FromSeconds(1);
+        var maxTimerInterval = TimeSpan.FromMilliseconds(int.MaxValue);
 
-        MaxInitWaitTime = maxInitWaitTime;
+        PollInterval = minPollInterval <= pollInterval && pollInterval <= maxTimerInterval
+            ? pollInterval
+            : throw new ArgumentOutOfRangeException(nameof(pollInterval), pollInterval, $"Value must be between {minPollInterval} and {maxTimerInterval}.");
+
+        MaxInitWaitTime = maxInitWaitTime <= maxTimerInterval
+            ? maxInitWaitTime
+            : throw new ArgumentOutOfRangeException(nameof(maxInitWaitTime), maxInitWaitTime, $"Value must be less than or equal to {maxTimerInterval}.");
     }
 }
 
@@ -47,15 +52,18 @@ public class LazyLoad : PollingMode
     internal override string Identifier => "l";
 
     /// <summary>
-    /// Cache time to live value, minimum value is 1 seconds. (Default value is 60 seconds.)     
+    /// Cache time to live value.
     /// </summary>
     public TimeSpan CacheTimeToLive { get; }
 
     internal LazyLoad(TimeSpan cacheTimeToLive)
     {
-        CacheTimeToLive = cacheTimeToLive >= TimeSpan.FromSeconds(1)
+        var minCacheTimeToLive = TimeSpan.FromSeconds(1);
+        var maxCacheTimeToLive = TimeSpan.FromSeconds(int.MaxValue);
+
+        CacheTimeToLive = minCacheTimeToLive <= cacheTimeToLive && cacheTimeToLive <= maxCacheTimeToLive
             ? cacheTimeToLive
-            : throw new ArgumentOutOfRangeException(nameof(cacheTimeToLive), "Value must be greater than or equal to 1 seconds.");
+            : throw new ArgumentOutOfRangeException(nameof(cacheTimeToLive), cacheTimeToLive, $"Value must be between {minCacheTimeToLive} and {maxCacheTimeToLive}.");
     }
 }
 

--- a/src/ConfigCatClient/Configuration/PollingModes.cs
+++ b/src/ConfigCatClient/Configuration/PollingModes.cs
@@ -11,8 +11,14 @@ public static class PollingModes
     /// <summary>
     /// Constructs a new auto polling mode.
     /// </summary>
-    /// <param name="pollInterval">Configuration refresh period. (Default value is 60 seconds.)</param>
-    /// <param name="maxInitWaitTime">Maximum waiting time between initialization and the first config acquisition. (Default value is 5 seconds.)</param>
+    /// <param name="pollInterval">
+    /// Configuration refresh period.
+    /// (Default value is 60 seconds. Minimum value is 1 second. Maximum value is <see cref="int.MaxValue"/> milliseconds.)
+    /// </param>
+    /// <param name="maxInitWaitTime">
+    /// Maximum waiting time between initialization and the first config acquisition.
+    /// (Default value is 5 seconds. Maximum value is <see cref="int.MaxValue"/> milliseconds. Negative values mean infinite waiting.)
+    /// </param>
     /// <returns>The auto polling mode.</returns>
     public static AutoPoll AutoPoll(TimeSpan? pollInterval = null, TimeSpan? maxInitWaitTime = null) =>
         new(pollInterval ?? TimeSpan.FromSeconds(60), maxInitWaitTime ?? TimeSpan.FromSeconds(5));
@@ -20,7 +26,10 @@ public static class PollingModes
     /// <summary>
     /// Constructs a new lazy load polling mode.
     /// </summary>
-    /// <param name="cacheTimeToLive">Cache time to live value, minimum value is 1 seconds. (Default value is 60 seconds.)</param>
+    /// <param name="cacheTimeToLive">
+    /// Cache time to live value.
+    /// (Default value is 60 seconds. Minimum value is 1 second. Maximum value is <see cref="int.MaxValue"/> seconds.)
+    /// </param>
     /// <returns>The lazy load polling mode.</returns>
     public static LazyLoad LazyLoad(TimeSpan? cacheTimeToLive = null) =>
         new(cacheTimeToLive ?? TimeSpan.FromSeconds(60));


### PR DESCRIPTION
### Describe the purpose of your pull request

Revise the ranges in which `AutoPoll.PollInterval`, `AutoPoll.MaxInitWaitTime` and `LazyLoad.CacheTimeToLive` are valid.

Also, makes infinite init wait possible in `AutoPollConfigService`.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
