### PR TITLE
Prevent System.Net.Http version conflicts

### DIFF
--- a/src/ConfigCatClient/ConfigCatClient.csproj
+++ b/src/ConfigCatClient/ConfigCatClient.csproj
@@ -42,28 +42,40 @@
     <Optimize>true</Optimize>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <DefineConstants>USE_NEWTONSOFT_JSON</DefineConstants>
-  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(TargetFramework)' == 'net45'">
+      <PropertyGroup>
+        <DefineConstants>USE_NEWTONSOFT_JSON</DefineConstants>
+      </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageReference Include="System.Memory" Version="4.5.5" />
-  </ItemGroup>
+      <ItemGroup>
+        <Reference Include="System.Net.Http" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+        <PackageReference Include="System.Memory" Version="4.5.5" />
+      </ItemGroup>
+    </When>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">
-    <PackageReference Include="System.Text.Json" Version="6.0.5" />
-  </ItemGroup>
+    <When Condition="'$(TargetFramework)' == 'net461'">
+      <ItemGroup>
+        <Reference Include="System.Net.Http" />
+        <PackageReference Include="System.Text.Json" Version="6.0.5" />
+      </ItemGroup>
+    </When>
+
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="System.Net.Http" Version="4.3.4" />
+        <PackageReference Include="System.Text.Json" Version="6.0.5" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
 
   <ItemGroup>
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <!--Do not remove this reference, it was added due to a SNYK security report-->
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <None Include="icon.png" Pack="true" Visible="false" PackagePath="" />


### PR DESCRIPTION
### Describe the purpose of your pull request

The library referenced a specific version of the `System.Net.Http` assembly (v4.3.4), which could cause version conflict issues in the case of `net45` and `net461` targets. This PR aims to solve this by changing the reference to the built-in version (v4.0.0), which is shipped as a part of the framework.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
