### PR TITLE
Revise dependencies

### DIFF
--- a/src/ConfigCatClient/ConfigCatClient.csproj
+++ b/src/ConfigCatClient/ConfigCatClient.csproj
@@ -56,6 +56,8 @@
       <ItemGroup>
         <Reference Include="System.Net.Http" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+        <!--Do not remove this reference, it was added due to a SNYK security report-->
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
         <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
         <PackageReference Include="System.Memory" Version="4.5.5" />
       </ItemGroup>
@@ -64,16 +66,33 @@
     <When Condition="'$(TargetFramework)' == 'net461'">
       <ItemGroup>
         <Reference Include="System.Net.Http" />
-        <PackageReference Include="System.Text.Json" Version="6.0.5" />
+        <!--Do not remove this reference, it was added due to a SNYK security report-->
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+        <PackageReference Include="System.Text.Json" Version="6.0.0" />
       </ItemGroup>
     </When>
 
-    <Otherwise>
+    <When Condition="'$(TargetFramework)' == 'netstandard2.0'">
       <ItemGroup>
-        <PackageReference Include="System.Net.Http" Version="4.3.4" />
-        <PackageReference Include="System.Text.Json" Version="6.0.5" />
+        <!--Do not remove this reference, it was added due to a SNYK security report-->
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+        <PackageReference Include="System.Text.Json" Version="6.0.0" />
       </ItemGroup>
-    </Otherwise>
+    </When>
+
+    <When Condition="'$(TargetFramework)' == 'netstandard2.1'">
+      <ItemGroup>
+        <!--Do not remove this reference, it was added due to a SNYK security report-->
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+        <PackageReference Include="System.Text.Json" Version="6.0.0" />
+      </ItemGroup>
+    </When>
+
+    <When Condition="'$(TargetFramework)' == 'net5.0'">
+      <ItemGroup>
+        <PackageReference Include="System.Text.Json" Version="6.0.0" />
+      </ItemGroup>
+    </When>
   </Choose>
 
   <ItemGroup>
@@ -82,8 +101,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
-    <!--Do not remove this reference, it was added due to a SNYK security report-->
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <None Include="icon.png" Pack="true" Visible="false" PackagePath="" />
     <None Include="..\..\README.md" Pack="true" PackagePath="" />
   </ItemGroup>


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR is kind of a follow-up to https://github.com/configcat/.net-sdk/pull/68

I revised the package references of other targets than .NET framework targets as well and it seems to me that we have some unnecessary or questionable references:

* `System.Net.Http` (v4.3.4): this is an OOB (out-of-band) package which is for backporting newer improvements/fixes for older runtimes. However, [MS don't advise using the separate `System.Net.Http` NuGet package anymore](https://stackoverflow.com/a/58874418) because it [may lead to complications](https://github.com/dotnet/runtime/issues/20777#issuecomment-338418610) (as we also experienced that ourselves). In the case of .NET 5+, referencing the package is pointless anyway because those runtimes include a newer version. In the case of older targets, I think we shouldn't require this package either but we'd better leave the decision to the end user to reference it in their application if they want to. So I propose removing this dependency completely.
* `System.Text.RegularExpressions` (v4.3.1): this is very similar to `System.Net.Http` but, based on the comment, it contains some security fix(es). So in targets older than .NET 5, it may make sense to require this dependency. However, I think it would be better to leave the decision to the end user in this case as well: let them reference it in their applications if they see fit but I'm not sure that we should make the decision for them by requiring this dependency via our library.
* `System.Text.Json` (v6.0.5): our library uses features which was introduced in `System.Text.Json` v6.0, so we need this one (except for .NET 6 which already includes it). However, I recommend referencing the oldest version that works for us instead of some arbitrary patch version. This version would be v6.0.0.

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
