### PR TITLE
Correct ClientReady hook in Auto Poll mode

### DIFF
--- a/src/ConfigCatClient/ConfigService/AutoPollConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/AutoPollConfigService.cs
@@ -146,9 +146,9 @@ internal sealed class AutoPollConfigService : ConfigServiceBase, IConfigService
         return await this.ConfigCache.GetAsync(base.CacheKey, cancellationToken).ConfigureAwait(false);
     }
 
-    protected override void OnConfigUpdated(ProjectConfig newConfig)
+    protected override void OnConfigFetched(ProjectConfig newConfig)
     {
-        base.OnConfigUpdated(newConfig);
+        base.OnConfigFetched(newConfig);
         SignalInitialization();
     }
 

--- a/src/ConfigCatClient/ConfigService/ConfigServiceBase.cs
+++ b/src/ConfigCatClient/ConfigService/ConfigServiceBase.cs
@@ -91,16 +91,16 @@ internal abstract class ConfigServiceBase : IDisposable
         if (fetchResult.IsSuccess
             || fetchResult.Config.TimeStamp > latestConfig.TimeStamp && (!fetchResult.Config.IsEmpty || latestConfig.IsEmpty))
         {
+            this.ConfigCache.Set(this.CacheKey, fetchResult.Config);
+
             latestConfig = fetchResult.Config;
+        }
 
-            this.ConfigCache.Set(this.CacheKey, latestConfig);
+        OnConfigFetched(fetchResult.Config);
 
-            OnConfigUpdated(latestConfig);
-
-            if (fetchResult.IsSuccess)
-            {
-                OnConfigChanged(latestConfig);
-            }
+        if (fetchResult.IsSuccess)
+        {
+            OnConfigChanged(fetchResult.Config);
         }
 
         return new ConfigWithFetchResult(latestConfig, fetchResult);
@@ -128,22 +128,22 @@ internal abstract class ConfigServiceBase : IDisposable
         if (fetchResult.IsSuccess
             || fetchResult.Config.TimeStamp > latestConfig.TimeStamp && (!fetchResult.Config.IsEmpty || latestConfig.IsEmpty))
         {
+            await this.ConfigCache.SetAsync(this.CacheKey, fetchResult.Config, cancellationToken).ConfigureAwait(false);
+
             latestConfig = fetchResult.Config;
+        }
 
-            await this.ConfigCache.SetAsync(this.CacheKey, latestConfig, cancellationToken).ConfigureAwait(false);
+        OnConfigFetched(fetchResult.Config);
 
-            OnConfigUpdated(latestConfig);
-
-            if (fetchResult.IsSuccess)
-            {
-                OnConfigChanged(latestConfig);
-            }
+        if (fetchResult.IsSuccess)
+        {
+            OnConfigChanged(fetchResult.Config);
         }
 
         return new ConfigWithFetchResult(latestConfig, fetchResult);
     }
 
-    protected virtual void OnConfigUpdated(ProjectConfig newConfig) { }
+    protected virtual void OnConfigFetched(ProjectConfig newConfig) { }
 
     protected virtual void OnConfigChanged(ProjectConfig newConfig)
     {


### PR DESCRIPTION
### Describe the purpose of your pull request

So far the `ClientReady` event has fired in Auto Poll mode only when receiving 200, 304, 403 or 404 status code. In other cases (including the case of network errors) `maxInitWaitTime` has been waited before firing `ClientReady`.

Breaking changes:
* Change the behavior of the `ClientReady` hook to fire after the completion of the first fetch operation in Auto Poll mode - regardless of success or failure - to make the behavior consistent with other SDKs.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
