### PR TITLE
Implement non-blocking synchronous evaluation (snapshot API)

### DIFF
--- a/.github/workflows/linux-macOS-CI.yml
+++ b/.github/workflows/linux-macOS-CI.yml
@@ -13,12 +13,9 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 
 jobs:
-  build-test:
-    name: Build & test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ macos-latest, ubuntu-latest ]
+  build-test-ubuntu:
+    name: Build & test (Ubuntu)
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
@@ -34,5 +31,21 @@ jobs:
         run: |
           dotnet test src/ConfigCat.Client.Tests/ConfigCat.Client.Tests.csproj -c Release -f netcoreapp3.1 --no-restore
           dotnet test src/ConfigCat.Client.Tests/ConfigCat.Client.Tests.csproj -c Release -f net5.0 --no-restore
+          dotnet test src/ConfigCat.Client.Tests/ConfigCat.Client.Tests.csproj -c Release -f net6.0 --no-restore
+          dotnet test src/ConfigCat.Client.Tests/ConfigCat.Client.Tests.csproj -c Release -f net8.0 --no-restore
+  build-test-macos:
+    name: Build & test (macOS)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: | 
+            6.0.x
+            8.0.x
+      - name: Restore
+        run: dotnet restore src
+      - name: Test
+        run: |
           dotnet test src/ConfigCat.Client.Tests/ConfigCat.Client.Tests.csproj -c Release -f net6.0 --no-restore
           dotnet test src/ConfigCat.Client.Tests/ConfigCat.Client.Tests.csproj -c Release -f net8.0 --no-restore

--- a/samples/ASP.NETCore/WebApplication/Controllers/BackdoorController.cs
+++ b/samples/ASP.NETCore/WebApplication/Controllers/BackdoorController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -23,9 +23,9 @@ public class BackdoorController : Controller
     // This endpoint can be called by Configcat Webhooks https://configcat.com/docs/advanced/notifications-webhooks
     [HttpGet]
     [Route("configcatchanged")]
-    public IActionResult ConfigCatChanged()
+    public async Task<IActionResult> ConfigCatChanged()
     {
-        this.configCatClient.ForceRefresh();
+        await this.configCatClient.ForceRefreshAsync();
 
         return Ok("configCatClient.ForceRefresh() invoked");
     }

--- a/samples/ASP.NETCore/WebApplication/Controllers/HomeController.cs
+++ b/samples/ASP.NETCore/WebApplication/Controllers/HomeController.cs
@@ -1,5 +1,5 @@
-using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using ConfigCat.Client;
 using Microsoft.AspNetCore.Mvc;
 using WebApplication.Models;
@@ -15,9 +15,9 @@ public class HomeController : Controller
         this.configCatClient = configCatClient;
     }
 
-    public IActionResult Index()
+    public async Task<IActionResult> Index()
     {
-        ViewData["Message1"] = this.configCatClient.GetValue("isAwesomeFeatureEnabled", false);
+        ViewData["Message1"] = await this.configCatClient.GetValueAsync("isAwesomeFeatureEnabled", false);
 
         var userObject = new User("<Some UserID>")
         {
@@ -30,7 +30,7 @@ public class HomeController : Controller
             }
         };
 
-        ViewData["Message2"] = this.configCatClient.GetValue("isPOCFeatureEnabled", false, userObject);
+        ViewData["Message2"] = await this.configCatClient.GetValueAsync("isPOCFeatureEnabled", false, userObject);
 
         return View();
     }

--- a/samples/ConsoleApp/Program.cs
+++ b/samples/ConsoleApp/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using ConfigCat.Client;
 
 // Creating the ConfigCat client instance using the SDK Key
@@ -21,5 +21,5 @@ var user = new User("<SOME USERID>")
 };
 
 // Accessing feature flag or setting value
-var value = client.GetValue("isPOCFeatureEnabled", false, user);
+var value = await client.GetValueAsync("isPOCFeatureEnabled", false, user);
 Console.WriteLine($"isPOCFeatureEnabled: {value}");

--- a/samples/FileLoggerSample.cs
+++ b/samples/FileLoggerSample.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using System.IO;
+using System.Threading.Tasks;
 using ConfigCat.Client;
 
 namespace SampleApplication
@@ -56,7 +57,7 @@ namespace SampleApplication
             }
         }
 
-        static void Main(string[] args)
+        static async Task Main(string[] args)
         {
             var filePath = Path.Combine(Environment.CurrentDirectory, "configcat.log");
             var logLevel = LogLevel.Warning; // Log only WARNING and higher entries (warnings and errors).
@@ -67,7 +68,7 @@ namespace SampleApplication
                 options.PollingMode = PollingModes.AutoPoll(pollInterval: TimeSpan.FromSeconds(5));
             });
 
-            var feature = client.GetValue("keyNotExists", "N/A");
+            var feature = await client.GetValueAsync("keyNotExists", "N/A");
 
             Console.ReadKey();
         }

--- a/src/ConfigCat.Client.Tests/ConfigCacheTests.cs
+++ b/src/ConfigCat.Client.Tests/ConfigCacheTests.cs
@@ -242,7 +242,7 @@ public class ConfigCacheTests
     public void CachePayloadSerialization_ShouldBePlatformIndependent(string configJson, string timeStamp, string httpETag, string expectedPayload)
     {
         var timeStampDateTime = DateTimeOffset.ParseExact(timeStamp, "o", CultureInfo.InvariantCulture).UtcDateTime;
-        var pc = new ProjectConfig(configJson, configJson.Deserialize<Config>(), timeStampDateTime, httpETag);
+        var pc = new ProjectConfig(configJson, Config.Deserialize(configJson.AsMemory()), timeStampDateTime, httpETag);
 
         Assert.AreEqual(expectedPayload, ProjectConfig.Serialize(pc));
     }

--- a/src/ConfigCat.Client.Tests/ConfigCat.Client.Tests.csproj
+++ b/src/ConfigCat.Client.Tests/ConfigCat.Client.Tests.csproj
@@ -8,6 +8,7 @@
     <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
+    <NoWarn>CS0618</NoWarn>
     <AssemblyOriginatorKeyFile>..\ConfigCatClient.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 

--- a/src/ConfigCat.Client.Tests/ConfigCatClientSnapshotTests.cs
+++ b/src/ConfigCat.Client.Tests/ConfigCatClientSnapshotTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using ConfigCat.Client.Cache;
+using ConfigCat.Client.ConfigService;
+using ConfigCat.Client.Configuration;
+using ConfigCat.Client.Evaluation;
+using ConfigCat.Client.Override;
+using ConfigCat.Client.Tests.Fakes;
+using ConfigCat.Client.Tests.Helpers;
+using ConfigCat.Client.Utils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace ConfigCat.Client.Tests;
+
+[TestClass]
+public class ConfigCatClientSnapshotTests
+{
+    [TestMethod]
+    public void DefaultInstanceDoesNotThrow()
+    {
+        const string key = "key";
+        const string defaultValue = "";
+
+        var snapshot = default(ConfigCatClientSnapshot);
+
+        Assert.AreEqual(ClientCacheState.NoFlagData, snapshot.CacheState);
+        Assert.IsNull(snapshot.FetchedConfig);
+        CollectionAssert.AreEqual(ArrayUtils.EmptyArray<string>(), snapshot.GetAllKeys().ToArray());
+        Assert.AreEqual("", snapshot.GetValue(key, defaultValue));
+        var evaluationDetails = snapshot.GetValueDetails(key, defaultValue);
+        Assert.IsNotNull(evaluationDetails);
+        Assert.AreEqual(key, evaluationDetails.Key);
+        Assert.AreEqual(defaultValue, evaluationDetails.Value);
+        Assert.IsTrue(evaluationDetails.IsDefaultValue);
+        Assert.IsNotNull(evaluationDetails.ErrorMessage);
+    }
+
+    [TestMethod]
+    public void CanMockSnapshot()
+    {
+        const ClientCacheState cacheState = ClientCacheState.HasUpToDateFlagData;
+        var fetchedConfig = new Config();
+        var keys = new[] { "key1", "key2" };
+        var evaluationDetails = new EvaluationDetails<string>("key1", "value");
+
+        var mock = new Mock<IConfigCatClientSnapshot>();
+        mock.SetupGet(m => m.CacheState).Returns(cacheState);
+        mock.SetupGet(m => m.FetchedConfig).Returns(fetchedConfig);
+        mock.Setup(m => m.GetAllKeys()).Returns(keys);
+        mock.Setup(m => m.GetValue(evaluationDetails.Key, It.IsAny<string>(), It.IsAny<User?>())).Returns(evaluationDetails.Value);
+        mock.Setup(m => m.GetValueDetails(evaluationDetails.Key, It.IsAny<string>(), It.IsAny<User?>())).Returns(evaluationDetails);
+
+        var snapshot = new ConfigCatClientSnapshot(mock.Object);
+
+        Assert.AreEqual(cacheState, snapshot.CacheState);
+        Assert.AreEqual(fetchedConfig, snapshot.FetchedConfig);
+        CollectionAssert.AreEqual(keys, snapshot.GetAllKeys().ToArray());
+        Assert.AreEqual(evaluationDetails.Value, snapshot.GetValue(evaluationDetails.Key, ""));
+        Assert.AreSame(evaluationDetails, snapshot.GetValueDetails(evaluationDetails.Key, ""));
+    }
+}

--- a/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
+++ b/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
@@ -217,7 +217,7 @@ public class ConfigCatClientTests
 
         sw.Stop();
 
-        Assert.IsTrue(sw.Elapsed >= delay - TimeSpan.FromMilliseconds(10), $"Elapsed time: {sw.Elapsed}");
+        Assert.IsTrue(sw.Elapsed >= delay - TimeSpan.FromMilliseconds(50), $"Elapsed time: {sw.Elapsed}"); // 50ms for tolerance
         Assert.IsTrue(sw.Elapsed <= delay + TimeSpan.FromMilliseconds(250), $"Elapsed time: {sw.Elapsed}"); // 250ms for tolerance
         Assert.IsTrue(actualValue);
     }
@@ -252,7 +252,7 @@ public class ConfigCatClientTests
 
         sw.Stop();
 
-        Assert.IsTrue(sw.Elapsed >= maxInitWaitTime - TimeSpan.FromMilliseconds(10), $"Elapsed time: {sw.Elapsed}");
+        Assert.IsTrue(sw.Elapsed >= maxInitWaitTime - TimeSpan.FromMilliseconds(50), $"Elapsed time: {sw.Elapsed}"); // 50ms for tolerance
         Assert.IsTrue(sw.Elapsed <= maxInitWaitTime + TimeSpan.FromMilliseconds(250), $"Elapsed time: {sw.Elapsed}"); // 250ms for tolerance
 
         Assert.IsFalse(actualValue);
@@ -312,7 +312,7 @@ public class ConfigCatClientTests
 
         sw.Stop();
 
-        Assert.IsTrue(sw.Elapsed >= maxInitWaitTime - TimeSpan.FromMilliseconds(10), $"Elapsed time: {sw.Elapsed}");
+        Assert.IsTrue(sw.Elapsed >= maxInitWaitTime - TimeSpan.FromMilliseconds(50), $"Elapsed time: {sw.Elapsed}"); // 50ms for tolerance
         Assert.IsTrue(sw.Elapsed <= maxInitWaitTime + TimeSpan.FromMilliseconds(250), $"Elapsed time: {sw.Elapsed}"); // 250ms for tolerance
 
         Assert.AreEqual(ClientCacheState.NoFlagData, cacheState);
@@ -360,7 +360,7 @@ public class ConfigCatClientTests
 
         sw.Stop();
 
-        Assert.IsTrue(sw.Elapsed >= maxInitWaitTime - TimeSpan.FromMilliseconds(10), $"Elapsed time: {sw.Elapsed}");
+        Assert.IsTrue(sw.Elapsed >= maxInitWaitTime - TimeSpan.FromMilliseconds(50), $"Elapsed time: {sw.Elapsed}"); // 50ms for tolerance
         Assert.IsTrue(sw.Elapsed <= maxInitWaitTime + TimeSpan.FromMilliseconds(250), $"Elapsed time: {sw.Elapsed}"); // 250ms for tolerance
 
         Assert.AreEqual(ClientCacheState.HasCachedFlagDataOnly, cacheState);

--- a/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
+++ b/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
@@ -1782,7 +1782,7 @@ public class ConfigCatClientTests
         var flagEvaluatedEvents = new List<FlagEvaluatedEventArgs>();
         var errorEvents = new List<ConfigCatClientErrorEventArgs>();
 
-        EventHandler handleClientReady = (s, e) => clientReadyCallCount++;
+        EventHandler<ClientReadyEventArgs> handleClientReady = (s, e) => clientReadyCallCount++;
         EventHandler<ConfigChangedEventArgs> handleConfigChanged = (s, e) => configChangedEvents.Add(e);
         EventHandler<FlagEvaluatedEventArgs> handleFlagEvaluated = (s, e) => flagEvaluatedEvents.Add(e);
         EventHandler<ConfigCatClientErrorEventArgs> handleError = (s, e) => errorEvents.Add(e);
@@ -1893,6 +1893,8 @@ public class ConfigCatClientTests
             base.Dispose(disposing);
         }
 
+        public Task<ClientCacheState> ReadyTask => Task.FromResult(ClientCacheState.NoFlagData);
+
         public ValueTask<ProjectConfig> GetConfigAsync(CancellationToken cancellationToken = default)
         {
             return new ValueTask<ProjectConfig>(ProjectConfig.Empty);
@@ -1912,5 +1914,7 @@ public class ConfigCatClientTests
         {
             return RefreshResult.Success();
         }
+
+        public override ClientCacheState GetCacheState(ProjectConfig cachedConfig) => ClientCacheState.NoFlagData;
     }
 }

--- a/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
+++ b/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
@@ -1490,7 +1490,7 @@ public class ConfigCatClientTests
 
             if (pollingMode == nameof(AutoPoll))
             {
-                Assert.IsTrue(((AutoPollConfigService)configService).WaitForInitialization());
+                Assert.IsTrue(await ((AutoPollConfigService)configService).InitializationTask);
                 expectedFetchAsyncCount++;
             }
 
@@ -1605,7 +1605,7 @@ public class ConfigCatClientTests
 
             if (pollingMode == nameof(AutoPoll))
             {
-                Assert.IsTrue(((AutoPollConfigService)configService).WaitForInitialization());
+                Assert.IsTrue(await ((AutoPollConfigService)configService).InitializationTask);
                 expectedFetchAsyncCount++;
             }
 

--- a/src/ConfigCat.Client.Tests/DeserializerTests.cs
+++ b/src/ConfigCat.Client.Tests/DeserializerTests.cs
@@ -19,7 +19,8 @@ public class DeserializerTests
             return settings;
         };
 
-        Assert.IsNotNull("{\"p\": {\"u\": \"http://example.com\", \"r\": 0}}".DeserializeOrDefault<Config>());
+        var config = Config.Deserialize("{\"p\": {\"u\": \"http://example.com\", \"r\": 0}}".AsMemory(), tolerant: false);
+        Assert.IsNotNull(config);
     }
 
     [DataRow(false)]

--- a/src/ConfigCat.Client.Tests/EvaluationLogTests.cs
+++ b/src/ConfigCat.Client.Tests/EvaluationLogTests.cs
@@ -180,7 +180,7 @@ public class EvaluationLogTests
     {
         var filePath = Path.Combine(TestDataRootPath, testSetName + ".json");
         var fileContent = File.ReadAllText(filePath);
-        var testSet = SerializationExtensions.Deserialize<TestSet>(fileContent);
+        var testSet = fileContent.AsMemory().Deserialize<TestSet>();
 
         foreach (var testCase in testSet!.tests ?? ArrayUtils.EmptyArray<TestCase>())
         {
@@ -200,10 +200,10 @@ public class EvaluationLogTests
 
     private static void RunTest(string testSetName, string? sdkKey, string? baseUrlOrOverrideFileName, string key, string? defaultValue, string? userObject, string? expectedReturnValue, string expectedLogFileName)
     {
-        var defaultValueParsed = defaultValue?.Deserialize<JsonValue>()!.ToSettingValue(out var settingType).GetValue();
-        var expectedReturnValueParsed = expectedReturnValue?.Deserialize<JsonValue>()!.ToSettingValue(out _).GetValue();
+        var defaultValueParsed = defaultValue?.AsMemory().Deserialize<JsonValue>()!.ToSettingValue(out var settingType).GetValue();
+        var expectedReturnValueParsed = expectedReturnValue?.AsMemory().Deserialize<JsonValue>()!.ToSettingValue(out _).GetValue();
 
-        var userObjectParsed = userObject?.Deserialize<Dictionary<string, string>?>();
+        var userObjectParsed = userObject?.AsMemory().Deserialize<Dictionary<string, string>?>();
         User? user;
         if (userObjectParsed is not null)
         {

--- a/src/ConfigCat.Client.Tests/Fakes/FakeExternalCache.cs
+++ b/src/ConfigCat.Client.Tests/Fakes/FakeExternalCache.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ConfigCat.Client.Tests.Fakes;
+
+internal sealed class FakeExternalCache : IConfigCatCache
+{
+    public volatile string? CachedValue = null;
+
+    public string? Get(string key) => this.CachedValue;
+
+    public Task<string?> GetAsync(string key, CancellationToken cancellationToken = default) => Task.FromResult(Get(key));
+
+    public void Set(string key, string value) => this.CachedValue = value;
+
+    public Task SetAsync(string key, string value, CancellationToken cancellationToken = default)
+    {
+        Set(key, value);
+        return Task.FromResult(0);
+    }
+}
+
+internal sealed class FaultyFakeExternalCache : IConfigCatCache
+{
+    public string? Get(string key) => throw new ApplicationException("Operation failed :(");
+
+    public Task<string?> GetAsync(string key, CancellationToken cancellationToken = default) => Task.FromResult(Get(key));
+
+    public void Set(string key, string value) => throw new ApplicationException("Operation failed :(");
+
+    public Task SetAsync(string key, string value, CancellationToken cancellationToken = default)
+    {
+        Set(key, value);
+        return Task.FromResult(0);
+    }
+}

--- a/src/ConfigCat.Client.Tests/Helpers/ConfigHelper.cs
+++ b/src/ConfigCat.Client.Tests/Helpers/ConfigHelper.cs
@@ -8,7 +8,7 @@ internal static class ConfigHelper
 {
     public static ProjectConfig FromString(string configJson, string? httpETag, DateTime timeStamp)
     {
-        return new ProjectConfig(configJson, configJson.Deserialize<Config>(), timeStamp, httpETag);
+        return new ProjectConfig(configJson, Config.Deserialize(configJson.AsMemory()), timeStamp, httpETag);
     }
 
     public static ProjectConfig FromFile(string configJsonFilePath, string? httpETag, DateTime timeStamp)

--- a/src/ConfigCat.Client.Tests/Helpers/ConfigLocation.LocalFile.cs
+++ b/src/ConfigCat.Client.Tests/Helpers/ConfigLocation.LocalFile.cs
@@ -22,7 +22,7 @@ public partial record class ConfigLocation
             using Stream stream = File.OpenRead(FilePath);
             using StreamReader reader = new(stream);
             var configJson = reader.ReadToEnd();
-            return configJson.Deserialize<Config>() ?? throw new InvalidOperationException("Invalid config JSON content: " + configJson);
+            return Config.Deserialize(configJson.AsMemory());
         }
     }
 }

--- a/src/ConfigCat.Client.Tests/OverrideTests.cs
+++ b/src/ConfigCat.Client.Tests/OverrideTests.cs
@@ -622,9 +622,9 @@ public class OverrideTests
         const string key = "flag";
         var overrideValue =
 #if USE_NEWTONSOFT_JSON
-            overrideValueJson.Deserialize<Newtonsoft.Json.Linq.JToken>()!;
+            overrideValueJson.AsMemory().Deserialize<Newtonsoft.Json.Linq.JToken>();
 #else
-            overrideValueJson.Deserialize<System.Text.Json.JsonElement>();
+            overrideValueJson.AsMemory().Deserialize<System.Text.Json.JsonElement>();
 #endif
 
         var filePath = Path.GetTempFileName();

--- a/src/ConfigCatClient/ConfigCatClient.cs
+++ b/src/ConfigCatClient/ConfigCatClient.cs
@@ -265,6 +265,7 @@ public sealed class ConfigCatClient : IConfigCatClient
     }
 
     /// <inheritdoc />
+    [Obsolete("This method may lead to an unresponsive application (see remarks), thus it will be removed from the public API in a future major version. Please use either the async version of the method or snaphots.")]
     public T GetValue<T>(string key, T defaultValue, User? user = null)
     {
         if (key is null)
@@ -341,6 +342,7 @@ public sealed class ConfigCatClient : IConfigCatClient
     }
 
     /// <inheritdoc />
+    [Obsolete("This method may lead to an unresponsive application (see remarks), thus it will be removed from the public API in a future major version. Please use either the async version of the method or snaphots.")]
     public EvaluationDetails<T> GetValueDetails<T>(string key, T defaultValue, User? user = null)
     {
         if (key is null)
@@ -411,6 +413,7 @@ public sealed class ConfigCatClient : IConfigCatClient
     }
 
     /// <inheritdoc />
+    [Obsolete("This method may lead to an unresponsive application (see remarks), thus it will be removed from the public API in a future major version. Please use either the async version of the method or snaphots.")]
     public IReadOnlyCollection<string> GetAllKeys()
     {
         const string defaultReturnValue = "empty collection";
@@ -455,6 +458,7 @@ public sealed class ConfigCatClient : IConfigCatClient
     }
 
     /// <inheritdoc />
+    [Obsolete("This method may lead to an unresponsive application (see remarks), thus it will be removed from the public API in a future major version. Please use either the async version of the method or snaphots.")]
     public IReadOnlyDictionary<string, object?> GetAllValues(User? user = null)
     {
         const string defaultReturnValue = "empty dictionary";
@@ -525,6 +529,7 @@ public sealed class ConfigCatClient : IConfigCatClient
     }
 
     /// <inheritdoc />
+    [Obsolete("This method may lead to an unresponsive application (see remarks), thus it will be removed from the public API in a future major version. Please use either the async version of the method or snaphots.")]
     public IReadOnlyList<EvaluationDetails> GetAllValueDetails(User? user = null)
     {
         const string defaultReturnValue = "empty list";
@@ -591,6 +596,7 @@ public sealed class ConfigCatClient : IConfigCatClient
     }
 
     /// <inheritdoc />
+    [Obsolete("This method may lead to an unresponsive application (see remarks), thus it will be removed from the public API in a future major version. Please use either the async version of the method or snaphots.")]
     public RefreshResult ForceRefresh()
     {
         try

--- a/src/ConfigCatClient/ConfigCatClient.cs
+++ b/src/ConfigCatClient/ConfigCatClient.cs
@@ -124,7 +124,8 @@ public sealed class ConfigCatClient : IConfigCatClient
     }
 
     // For test purposes only
-    internal ConfigCatClient(IConfigService configService, IConfigCatLogger logger, IRolloutEvaluator evaluator, Hooks? hooks = null)
+    internal ConfigCatClient(IConfigService configService, IConfigCatLogger logger, IRolloutEvaluator evaluator,
+        OverrideBehaviour? overrideBehaviour = null, IOverrideDataSource? overrideDataSource = null, Hooks? hooks = null)
     {
         this.hooks = hooks ?? NullHooks.Instance;
         this.hooks.SetSender(this);
@@ -133,6 +134,9 @@ public sealed class ConfigCatClient : IConfigCatClient
         this.evaluationServices = new EvaluationServices(evaluator, hooksWrapper, new LoggerWrapper(logger, hooks));
 
         this.configService = configService;
+
+        this.overrideBehaviour = overrideBehaviour;
+        this.overrideDataSource = overrideDataSource;
     }
 
     /// <summary>

--- a/src/ConfigCatClient/ConfigCatClient.cs
+++ b/src/ConfigCatClient/ConfigCatClient.cs
@@ -23,8 +23,7 @@ public sealed class ConfigCatClient : IConfigCatClient
     internal static readonly ConfigCatClientCache Instances = new();
 
     private readonly string? sdkKey; // may be null in case of testing
-    private readonly LoggerWrapper logger;
-    private readonly IRolloutEvaluator configEvaluator;
+    private readonly EvaluationServices evaluationServices;
     private readonly IConfigService configService;
     private readonly IOverrideDataSource? overrideDataSource;
     private readonly OverrideBehaviour? overrideBehaviour;
@@ -33,6 +32,9 @@ public sealed class ConfigCatClient : IConfigCatClient
     // Volatile guarantees (see https://learn.microsoft.com/en-us/dotnet/api/system.threading.volatile) that such changes become visible to them *eventually*,
     // which is good enough in these cases.
     private volatile User? defaultUser;
+
+    private LoggerWrapper Logger => this.evaluationServices.Logger;
+    private IRolloutEvaluator ConfigEvaluator => this.evaluationServices.Evaluator;
 
     private static bool IsValidSdkKey(string sdkKey, bool customBaseUrl)
     {
@@ -68,33 +70,37 @@ public sealed class ConfigCatClient : IConfigCatClient
     /// <inheritdoc />
     public LogLevel LogLevel
     {
-        get => this.logger.LogLevel;
-        set => this.logger.LogLevel = value;
+        get => Logger.LogLevel;
+        set => Logger.LogLevel = value;
     }
 
     internal ConfigCatClient(string sdkKey, ConfigCatClientOptions options)
     {
         this.sdkKey = sdkKey;
+
         this.hooks = options.YieldHooks();
         this.hooks.SetSender(this);
 
-        // To avoid possible memory leaks, the components of the client should not hold a strong reference to the hooks object (see also SafeHooksWrapper).
+        // To avoid possible memory leaks, the components of the client or client snapshots should not
+        // hold a strong reference to the hooks object (see also SafeHooksWrapper).
         var hooksWrapper = new SafeHooksWrapper(this.hooks);
 
-        this.logger = new LoggerWrapper(options.Logger ?? ConfigCatClientOptions.CreateDefaultLogger(), hooksWrapper);
-        this.configEvaluator = new RolloutEvaluator(this.logger);
+        var logger = new LoggerWrapper(options.Logger ?? ConfigCatClientOptions.CreateDefaultLogger(), hooksWrapper);
+        var evaluator = new RolloutEvaluator(logger);
+
+        this.evaluationServices = new EvaluationServices(evaluator, hooksWrapper, logger);
 
         var cacheParameters = new CacheParameters
         (
             configCache: options.ConfigCache is not null
-                ? new ExternalConfigCache(options.ConfigCache, this.logger)
+                ? new ExternalConfigCache(options.ConfigCache, logger)
                 : ConfigCatClientOptions.CreateDefaultConfigCache(),
             cacheKey: GetCacheKey(sdkKey)
         );
 
         if (options.FlagOverrides is not null)
         {
-            this.overrideDataSource = options.FlagOverrides.BuildDataSource(this.logger);
+            this.overrideDataSource = options.FlagOverrides.BuildDataSource(logger);
             this.overrideBehaviour = options.FlagOverrides.OverrideBehaviour;
         }
 
@@ -106,15 +112,15 @@ public sealed class ConfigCatClient : IConfigCatClient
             ? DetermineConfigService(pollingMode,
                 new HttpConfigFetcher(options.CreateUri(sdkKey),
                         GetProductVersion(pollingMode),
-                        this.logger,
+                        logger,
                         options.HttpClientHandler,
                         options.IsCustomBaseUrl,
                         options.HttpTimeout),
                     cacheParameters,
-                    this.logger,
+                    logger,
                     options.Offline,
                     hooksWrapper)
-            : new NullConfigService(this.logger, hooksWrapper);
+            : new NullConfigService(logger, hooksWrapper);
     }
 
     // For test purposes only
@@ -124,9 +130,9 @@ public sealed class ConfigCatClient : IConfigCatClient
         this.hooks.SetSender(this);
         var hooksWrapper = new SafeHooksWrapper(this.hooks);
 
+        this.evaluationServices = new EvaluationServices(evaluator, hooksWrapper, new LoggerWrapper(logger, hooks));
+
         this.configService = configService;
-        this.logger = new LoggerWrapper(logger, hooksWrapper);
-        this.configEvaluator = evaluator;
     }
 
     /// <summary>
@@ -166,7 +172,7 @@ public sealed class ConfigCatClient : IConfigCatClient
 
         if (instanceAlreadyCreated && configurationAction is not null)
         {
-            instance.logger.ClientIsAlreadyCreated(sdkKey);
+            instance.Logger.ClientIsAlreadyCreated(sdkKey);
         }
 
         return instance;
@@ -276,12 +282,12 @@ public sealed class ConfigCatClient : IConfigCatClient
         try
         {
             settings = GetSettings();
-            evaluationDetails = this.configEvaluator.Evaluate(settings.Value, key, defaultValue, user, settings.RemoteConfig, this.logger);
+            evaluationDetails = ConfigEvaluator.Evaluate(settings.Value, key, defaultValue, user, settings.RemoteConfig, Logger);
             value = evaluationDetails.Value;
         }
         catch (Exception ex)
         {
-            this.logger.SettingEvaluationError(nameof(GetValue), key, nameof(defaultValue), defaultValue, ex);
+            Logger.SettingEvaluationError(nameof(GetValue), key, nameof(defaultValue), defaultValue, ex);
             evaluationDetails = EvaluationDetails.FromDefaultValue(key, defaultValue, fetchTime: settings.RemoteConfig?.TimeStamp, user, ex.Message, ex);
             value = defaultValue;
         }
@@ -312,7 +318,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         try
         {
             settings = await GetSettingsAsync(cancellationToken).ConfigureAwait(false);
-            evaluationDetails = this.configEvaluator.Evaluate(settings.Value, key, defaultValue, user, settings.RemoteConfig, this.logger);
+            evaluationDetails = ConfigEvaluator.Evaluate(settings.Value, key, defaultValue, user, settings.RemoteConfig, Logger);
             value = evaluationDetails.Value;
         }
         catch (OperationCanceledException ex) when (ex.CancellationToken == cancellationToken)
@@ -321,7 +327,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         }
         catch (Exception ex)
         {
-            this.logger.SettingEvaluationError(nameof(GetValueAsync), key, nameof(defaultValue), defaultValue, ex);
+            Logger.SettingEvaluationError(nameof(GetValueAsync), key, nameof(defaultValue), defaultValue, ex);
             evaluationDetails = EvaluationDetails.FromDefaultValue(key, defaultValue, fetchTime: settings.RemoteConfig?.TimeStamp, user, ex.Message, ex);
             value = defaultValue;
         }
@@ -351,11 +357,11 @@ public sealed class ConfigCatClient : IConfigCatClient
         try
         {
             settings = GetSettings();
-            evaluationDetails = this.configEvaluator.Evaluate(settings.Value, key, defaultValue, user, settings.RemoteConfig, this.logger);
+            evaluationDetails = ConfigEvaluator.Evaluate(settings.Value, key, defaultValue, user, settings.RemoteConfig, Logger);
         }
         catch (Exception ex)
         {
-            this.logger.SettingEvaluationError(nameof(GetValueDetails), key, nameof(defaultValue), defaultValue, ex);
+            Logger.SettingEvaluationError(nameof(GetValueDetails), key, nameof(defaultValue), defaultValue, ex);
             evaluationDetails = EvaluationDetails.FromDefaultValue(key, defaultValue, fetchTime: settings.RemoteConfig?.TimeStamp, user, ex.Message, ex);
         }
 
@@ -384,7 +390,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         try
         {
             settings = await GetSettingsAsync(cancellationToken).ConfigureAwait(false);
-            evaluationDetails = this.configEvaluator.Evaluate(settings.Value, key, defaultValue, user, settings.RemoteConfig, this.logger);
+            evaluationDetails = ConfigEvaluator.Evaluate(settings.Value, key, defaultValue, user, settings.RemoteConfig, Logger);
         }
         catch (OperationCanceledException ex) when (ex.CancellationToken == cancellationToken)
         {
@@ -392,7 +398,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         }
         catch (Exception ex)
         {
-            this.logger.SettingEvaluationError(nameof(GetValueDetailsAsync), key, nameof(defaultValue), defaultValue, ex);
+            Logger.SettingEvaluationError(nameof(GetValueDetailsAsync), key, nameof(defaultValue), defaultValue, ex);
             evaluationDetails = EvaluationDetails.FromDefaultValue(key, defaultValue, fetchTime: settings.RemoteConfig?.TimeStamp, user, ex.Message, ex);
         }
 
@@ -407,7 +413,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         try
         {
             var settings = GetSettings();
-            if (!RolloutEvaluatorExtensions.CheckSettingsAvailable(settings.Value, this.logger, defaultReturnValue))
+            if (!RolloutEvaluatorExtensions.CheckSettingsAvailable(settings.Value, Logger, defaultReturnValue))
             {
                 return ArrayUtils.EmptyArray<string>();
             }
@@ -415,7 +421,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         }
         catch (Exception ex)
         {
-            this.logger.SettingEvaluationError(nameof(GetAllKeys), defaultReturnValue, ex);
+            Logger.SettingEvaluationError(nameof(GetAllKeys), defaultReturnValue, ex);
             return ArrayUtils.EmptyArray<string>();
         }
     }
@@ -427,7 +433,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         try
         {
             var settings = await GetSettingsAsync(cancellationToken).ConfigureAwait(false);
-            if (!RolloutEvaluatorExtensions.CheckSettingsAvailable(settings.Value, this.logger, defaultReturnValue))
+            if (!RolloutEvaluatorExtensions.CheckSettingsAvailable(settings.Value, Logger, defaultReturnValue))
             {
                 return ArrayUtils.EmptyArray<string>();
             }
@@ -439,7 +445,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         }
         catch (Exception ex)
         {
-            this.logger.SettingEvaluationError(nameof(GetAllKeysAsync), defaultReturnValue, ex);
+            Logger.SettingEvaluationError(nameof(GetAllKeysAsync), defaultReturnValue, ex);
             return ArrayUtils.EmptyArray<string>();
         }
     }
@@ -455,18 +461,18 @@ public sealed class ConfigCatClient : IConfigCatClient
         try
         {
             var settings = GetSettings();
-            evaluationDetailsArray = this.configEvaluator.EvaluateAll(settings.Value, user, settings.RemoteConfig, this.logger, defaultReturnValue, out evaluationExceptions);
+            evaluationDetailsArray = ConfigEvaluator.EvaluateAll(settings.Value, user, settings.RemoteConfig, Logger, defaultReturnValue, out evaluationExceptions);
             result = evaluationDetailsArray.ToDictionary(details => details.Key, details => details.Value);
         }
         catch (Exception ex)
         {
-            this.logger.SettingEvaluationError(nameof(GetAllValues), defaultReturnValue, ex);
+            Logger.SettingEvaluationError(nameof(GetAllValues), defaultReturnValue, ex);
             return new Dictionary<string, object?>();
         }
 
         if (evaluationExceptions is { Count: > 0 })
         {
-            this.logger.SettingEvaluationError(nameof(GetAllValues), "evaluation result", new AggregateException(evaluationExceptions));
+            Logger.SettingEvaluationError(nameof(GetAllValues), "evaluation result", new AggregateException(evaluationExceptions));
         }
 
         foreach (var evaluationDetails in evaluationDetailsArray)
@@ -488,7 +494,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         try
         {
             var settings = await GetSettingsAsync(cancellationToken).ConfigureAwait(false);
-            evaluationDetailsArray = this.configEvaluator.EvaluateAll(settings.Value, user, settings.RemoteConfig, this.logger, defaultReturnValue, out evaluationExceptions);
+            evaluationDetailsArray = ConfigEvaluator.EvaluateAll(settings.Value, user, settings.RemoteConfig, Logger, defaultReturnValue, out evaluationExceptions);
             result = evaluationDetailsArray.ToDictionary(details => details.Key, details => details.Value);
         }
         catch (OperationCanceledException ex) when (ex.CancellationToken == cancellationToken)
@@ -497,13 +503,13 @@ public sealed class ConfigCatClient : IConfigCatClient
         }
         catch (Exception ex)
         {
-            this.logger.SettingEvaluationError(nameof(GetAllValuesAsync), defaultReturnValue, ex);
+            Logger.SettingEvaluationError(nameof(GetAllValuesAsync), defaultReturnValue, ex);
             return new Dictionary<string, object?>();
         }
 
         if (evaluationExceptions is { Count: > 0 })
         {
-            this.logger.SettingEvaluationError(nameof(GetAllValuesAsync), "evaluation result", new AggregateException(evaluationExceptions));
+            Logger.SettingEvaluationError(nameof(GetAllValuesAsync), "evaluation result", new AggregateException(evaluationExceptions));
         }
 
         foreach (var evaluationDetails in evaluationDetailsArray)
@@ -524,17 +530,17 @@ public sealed class ConfigCatClient : IConfigCatClient
         try
         {
             var settings = GetSettings();
-            evaluationDetailsArray = this.configEvaluator.EvaluateAll(settings.Value, user, settings.RemoteConfig, this.logger, defaultReturnValue, out evaluationExceptions);
+            evaluationDetailsArray = ConfigEvaluator.EvaluateAll(settings.Value, user, settings.RemoteConfig, Logger, defaultReturnValue, out evaluationExceptions);
         }
         catch (Exception ex)
         {
-            this.logger.SettingEvaluationError(nameof(GetAllValueDetails), defaultReturnValue, ex);
+            Logger.SettingEvaluationError(nameof(GetAllValueDetails), defaultReturnValue, ex);
             return ArrayUtils.EmptyArray<EvaluationDetails>();
         }
 
         if (evaluationExceptions is { Count: > 0 })
         {
-            this.logger.SettingEvaluationError(nameof(GetAllValueDetails), "evaluation result", new AggregateException(evaluationExceptions));
+            Logger.SettingEvaluationError(nameof(GetAllValueDetails), "evaluation result", new AggregateException(evaluationExceptions));
         }
 
         foreach (var evaluationDetails in evaluationDetailsArray)
@@ -555,7 +561,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         try
         {
             var settings = await GetSettingsAsync(cancellationToken).ConfigureAwait(false);
-            evaluationDetailsArray = this.configEvaluator.EvaluateAll(settings.Value, user, settings.RemoteConfig, this.logger, defaultReturnValue, out evaluationExceptions);
+            evaluationDetailsArray = ConfigEvaluator.EvaluateAll(settings.Value, user, settings.RemoteConfig, Logger, defaultReturnValue, out evaluationExceptions);
         }
         catch (OperationCanceledException ex) when (ex.CancellationToken == cancellationToken)
         {
@@ -563,13 +569,13 @@ public sealed class ConfigCatClient : IConfigCatClient
         }
         catch (Exception ex)
         {
-            this.logger.SettingEvaluationError(nameof(GetAllValueDetailsAsync), defaultReturnValue, ex);
+            Logger.SettingEvaluationError(nameof(GetAllValueDetailsAsync), defaultReturnValue, ex);
             return ArrayUtils.EmptyArray<EvaluationDetails>();
         }
 
         if (evaluationExceptions is { Count: > 0 })
         {
-            this.logger.SettingEvaluationError(nameof(GetAllValueDetailsAsync), "evaluation result", new AggregateException(evaluationExceptions));
+            Logger.SettingEvaluationError(nameof(GetAllValueDetailsAsync), "evaluation result", new AggregateException(evaluationExceptions));
         }
 
         foreach (var evaluationDetails in evaluationDetailsArray)
@@ -589,7 +595,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         }
         catch (Exception ex)
         {
-            this.logger.ForceRefreshError(nameof(ForceRefresh), ex);
+            Logger.ForceRefreshError(nameof(ForceRefresh), ex);
             return RefreshResult.Failure(ex.Message, ex);
         }
     }
@@ -607,36 +613,38 @@ public sealed class ConfigCatClient : IConfigCatClient
         }
         catch (Exception ex)
         {
-            this.logger.ForceRefreshError(nameof(ForceRefreshAsync), ex);
+            Logger.ForceRefreshError(nameof(ForceRefreshAsync), ex);
             return RefreshResult.Failure(ex.Message, ex);
         }
     }
 
-    private SettingsWithRemoteConfig GetSettings()
+    private SettingsWithRemoteConfig GetSettings(bool syncWithExternalCache = true)
     {
         Dictionary<string, Setting> local;
         SettingsWithRemoteConfig remote;
         switch (this.overrideBehaviour)
         {
             case null:
-                return GetRemoteConfig();
+                return GetRemoteConfig(syncWithExternalCache);
             case OverrideBehaviour.LocalOnly:
                 return new SettingsWithRemoteConfig(this.overrideDataSource!.GetOverrides(), remoteConfig: null);
             case OverrideBehaviour.LocalOverRemote:
                 local = this.overrideDataSource!.GetOverrides();
-                remote = GetRemoteConfig();
+                remote = GetRemoteConfig(syncWithExternalCache);
                 return new SettingsWithRemoteConfig(remote.Value.MergeOverwriteWith(local), remote.RemoteConfig);
             case OverrideBehaviour.RemoteOverLocal:
                 local = this.overrideDataSource!.GetOverrides();
-                remote = GetRemoteConfig();
+                remote = GetRemoteConfig(syncWithExternalCache);
                 return new SettingsWithRemoteConfig(local.MergeOverwriteWith(remote.Value), remote.RemoteConfig);
             default:
                 throw new InvalidOperationException(); // execution should never get here
         }
 
-        SettingsWithRemoteConfig GetRemoteConfig()
+        SettingsWithRemoteConfig GetRemoteConfig(bool syncWithExternalCache = true)
         {
-            var config = this.configService.GetConfig();
+            var config = syncWithExternalCache
+                ? this.configService.GetConfig()
+                : this.configService.GetInMemoryConfig();
             var settings = !config.IsEmpty ? config.Config.Settings : null;
             return new SettingsWithRemoteConfig(settings, config);
         }
@@ -706,6 +714,20 @@ public sealed class ConfigCatClient : IConfigCatClient
     }
 
     /// <inheritdoc />
+    public Task<ClientCacheState> WaitForReadyAsync(CancellationToken cancellationToken = default)
+    {
+        return this.configService.ReadyTask.WaitAsync(cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public ConfigCatClientSnapshot Snapshot()
+    {
+        var settings = GetSettings(syncWithExternalCache: false);
+        var cacheState = this.configService.GetCacheState(settings.RemoteConfig ?? ProjectConfig.Empty);
+        return new ConfigCatClientSnapshot(this.evaluationServices, settings, this.defaultUser, cacheState);
+    }
+
+    /// <inheritdoc />
     public void ClearDefaultUser()
     {
         this.defaultUser = null;
@@ -727,7 +749,7 @@ public sealed class ConfigCatClient : IConfigCatClient
     }
 
     /// <inheritdoc/>
-    public event EventHandler? ClientReady
+    public event EventHandler<ClientReadyEventArgs>? ClientReady
     {
         add { this.hooks.ClientReady += value; }
         remove { this.hooks.ClientReady -= value; }
@@ -754,7 +776,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         remove { this.hooks.Error -= value; }
     }
 
-    private readonly struct SettingsWithRemoteConfig
+    internal readonly struct SettingsWithRemoteConfig
     {
         public SettingsWithRemoteConfig(Dictionary<string, Setting>? value, ProjectConfig? remoteConfig)
         {
@@ -764,5 +786,19 @@ public sealed class ConfigCatClient : IConfigCatClient
 
         public Dictionary<string, Setting>? Value { get; }
         public ProjectConfig? RemoteConfig { get; }
+    }
+
+    internal sealed class EvaluationServices
+    {
+        public EvaluationServices(IRolloutEvaluator evaluator, SafeHooksWrapper hooks, LoggerWrapper logger)
+        {
+            this.Evaluator = evaluator;
+            this.Hooks = hooks;
+            this.Logger = logger;
+        }
+
+        public readonly IRolloutEvaluator Evaluator;
+        public readonly SafeHooksWrapper Hooks;
+        public readonly LoggerWrapper Logger;
     }
 }

--- a/src/ConfigCatClient/ConfigCatClientSnapshot.cs
+++ b/src/ConfigCatClient/ConfigCatClientSnapshot.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using ConfigCat.Client.Evaluation;
+using ConfigCat.Client.Utils;
+
+using static ConfigCat.Client.ConfigCatClient;
+
+namespace ConfigCat.Client;
+
+/// <summary>
+/// Represents the state of <see cref="IConfigCatClient"/> captured at a specific point in time.
+/// </summary>
+public readonly struct ConfigCatClientSnapshot
+{
+    private readonly EvaluationServices evaluationServices;
+    private readonly SettingsWithRemoteConfig settings;
+    private readonly User? defaultUser;
+
+    private LoggerWrapper Logger => this.evaluationServices.Logger;
+    private IRolloutEvaluator ConfigEvaluator => this.evaluationServices.Evaluator;
+    private SafeHooksWrapper Hooks => this.evaluationServices.Hooks;
+
+    internal ConfigCatClientSnapshot(EvaluationServices evaluationServices, SettingsWithRemoteConfig settings, User? defaultUser, ClientCacheState cacheState)
+    {
+        this.evaluationServices = evaluationServices;
+        this.settings = settings;
+        this.defaultUser = defaultUser;
+        CacheState = cacheState;
+    }
+
+    /// <summary>
+    /// The state of the local cache at the time the snapshot was created.
+    /// </summary>
+    public ClientCacheState CacheState { get; }
+
+    /// <summary>
+    /// The latest config which has been fetched from the remote server.
+    /// </summary>
+    public IConfig? FetchedConfig => this.settings.RemoteConfig?.Config;
+
+    /// <summary>
+    /// Returns the available setting keys.
+    /// </summary>
+    /// <remarks>
+    /// In case the client is configured to use flag override, this will also include the keys provided by the flag override.
+    /// </remarks>
+    /// <returns>The collection of keys.</returns>
+    public IReadOnlyCollection<string> GetAllKeys()
+    {
+        return this.settings.Value is { } settings ? settings.ReadOnlyKeys() : ArrayUtils.EmptyArray<string>();
+    }
+
+    /// <summary>
+    /// Returns the value of a feature flag or setting identified by <paramref name="key"/> synchronously, based on the snapshot.
+    /// </summary>
+    /// <remarks>
+    /// It is important to provide an argument for the <paramref name="defaultValue"/> parameter, specifically for the <typeparamref name="T"/> generic type parameter,
+    /// that matches the type of the feature flag or setting you are evaluating.<br/>
+    /// Please refer to <see href="https://configcat.com/docs/sdk-reference/dotnet/#setting-type-mapping">this table</see> for the corresponding types.
+    /// </remarks>
+    /// <typeparam name="T">
+    /// The type of the value. Only the following types are allowed:
+    /// <see cref="string"/>, <see cref="bool"/>, <see cref="int"/>, <see cref="long"/>, <see cref="double"/> and <see cref="object"/> (both nullable and non-nullable).<br/>
+    /// The type must correspond to the setting type, otherwise <paramref name="defaultValue"/> will be returned.
+    /// </typeparam>
+    /// <param name="key">Key of the feature flag or setting.</param>
+    /// <param name="defaultValue">In case of failure, this value will be returned.</param>
+    /// <param name="user">The User Object to use for evaluating targeting rules and percentage options.</param>
+    /// <returns>The value of the feature flag or setting.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="key"/> is an empty string.</exception>
+    /// <exception cref="ArgumentException"><typeparamref name="T"/> is not an allowed type.</exception>
+    public T GetValue<T>(string key, T defaultValue, User? user = null)
+    {
+        if (key is null)
+        {
+            throw new ArgumentNullException(nameof(key));
+        }
+
+        if (key.Length == 0)
+        {
+            throw new ArgumentException("Key cannot be empty.", nameof(key));
+        }
+
+        typeof(T).EnsureSupportedSettingClrType(nameof(T));
+
+        T value;
+        EvaluationDetails<T> evaluationDetails;
+        SettingsWithRemoteConfig settings = default;
+        user ??= this.defaultUser;
+        try
+        {
+            settings = this.settings;
+            evaluationDetails = ConfigEvaluator.Evaluate(settings.Value, key, defaultValue, user, settings.RemoteConfig, Logger);
+            value = evaluationDetails.Value;
+        }
+        catch (Exception ex)
+        {
+            Logger.SettingEvaluationError($"{nameof(ConfigCatClientSnapshot)}.{nameof(GetValue)}", key, nameof(defaultValue), defaultValue, ex);
+            evaluationDetails = EvaluationDetails.FromDefaultValue(key, defaultValue, fetchTime: settings.RemoteConfig?.TimeStamp, user, ex.Message, ex);
+            value = defaultValue;
+        }
+
+        Hooks.RaiseFlagEvaluated(evaluationDetails);
+        return value;
+    }
+
+    /// <summary>
+    /// Returns the value along with evaluation details of a feature flag or setting identified by <paramref name="key"/> synchronously, based on the snapshot.
+    /// </summary>
+    /// <remarks>
+    /// It is important to provide an argument for the <paramref name="defaultValue"/> parameter, specifically for the <typeparamref name="T"/> generic type parameter,
+    /// that matches the type of the feature flag or setting you are evaluating.<br/>
+    /// Please refer to <see href="https://configcat.com/docs/sdk-reference/dotnet/#setting-type-mapping">this table</see> for the corresponding types.
+    /// </remarks>
+    /// <typeparam name="T">
+    /// The type of the value. Only the following types are allowed:
+    /// <see cref="string"/>, <see cref="bool"/>, <see cref="int"/>, <see cref="long"/>, <see cref="double"/> and <see cref="object"/> (both nullable and non-nullable).<br/>
+    /// The type must correspond to the setting type, otherwise <paramref name="defaultValue"/> will be returned.
+    /// </typeparam>
+    /// <param name="key">Key of the feature flag or setting.</param>
+    /// <param name="defaultValue">In case of failure, this value will be returned.</param>
+    /// <param name="user">The User Object to use for evaluating targeting rules and percentage options.</param>
+    /// <returns>The value along with the details of evaluation of the feature flag or setting.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="key"/> is an empty string.</exception>
+    /// <exception cref="ArgumentException"><typeparamref name="T"/> is not an allowed type.</exception>
+    public EvaluationDetails<T> GetValueDetails<T>(string key, T defaultValue, User? user = null)
+    {
+        if (key is null)
+        {
+            throw new ArgumentNullException(nameof(key));
+        }
+
+        if (key.Length == 0)
+        {
+            throw new ArgumentException("Key cannot be empty.", nameof(key));
+        }
+
+        typeof(T).EnsureSupportedSettingClrType(nameof(T));
+
+        EvaluationDetails<T> evaluationDetails;
+        SettingsWithRemoteConfig settings = default;
+        user ??= this.defaultUser;
+        try
+        {
+            settings = this.settings;
+            evaluationDetails = ConfigEvaluator.Evaluate(settings.Value, key, defaultValue, user, settings.RemoteConfig, Logger);
+        }
+        catch (Exception ex)
+        {
+            Logger.SettingEvaluationError($"{nameof(ConfigCatClientSnapshot)}.{nameof(GetValueDetails)}", key, nameof(defaultValue), defaultValue, ex);
+            evaluationDetails = EvaluationDetails.FromDefaultValue(key, defaultValue, fetchTime: settings.RemoteConfig?.TimeStamp, user, ex.Message, ex);
+        }
+
+        Hooks.RaiseFlagEvaluated(evaluationDetails);
+        return evaluationDetails;
+    }
+}

--- a/src/ConfigCatClient/ConfigCatClientSnapshot.cs
+++ b/src/ConfigCatClient/ConfigCatClientSnapshot.cs
@@ -10,68 +10,66 @@ namespace ConfigCat.Client;
 /// <summary>
 /// Represents the state of <see cref="IConfigCatClient"/> captured at a specific point in time.
 /// </summary>
-public readonly struct ConfigCatClientSnapshot
+public readonly struct ConfigCatClientSnapshot : IConfigCatClientSnapshot
 {
-    private readonly EvaluationServices evaluationServices;
+    private readonly object? evaluationServicesOrFakeImpl; // an instance of either EvaluationServices or IConfigCatClientSnapshot
     private readonly SettingsWithRemoteConfig settings;
     private readonly User? defaultUser;
-
-    private LoggerWrapper Logger => this.evaluationServices.Logger;
-    private IRolloutEvaluator ConfigEvaluator => this.evaluationServices.Evaluator;
-    private SafeHooksWrapper Hooks => this.evaluationServices.Hooks;
+    private readonly ClientCacheState cacheState;
 
     internal ConfigCatClientSnapshot(EvaluationServices evaluationServices, SettingsWithRemoteConfig settings, User? defaultUser, ClientCacheState cacheState)
     {
-        this.evaluationServices = evaluationServices;
+        this.evaluationServicesOrFakeImpl = evaluationServices;
         this.settings = settings;
         this.defaultUser = defaultUser;
-        CacheState = cacheState;
+        this.cacheState = cacheState;
     }
 
     /// <summary>
-    /// The state of the local cache at the time the snapshot was created.
+    /// For testing purposes. This constructor allows you to create an instance
+    /// which will use the fake implementation you provide instead of executing the built-in logic.
     /// </summary>
-    public ClientCacheState CacheState { get; }
+    public ConfigCatClientSnapshot(IConfigCatClientSnapshot impl)
+    {
+        this.evaluationServicesOrFakeImpl = impl;
+        this.settings = default;
+        this.defaultUser = default;
+        this.cacheState = default;
+    }
 
-    /// <summary>
-    /// The latest config which has been fetched from the remote server.
-    /// </summary>
-    public IConfig? FetchedConfig => this.settings.RemoteConfig?.Config;
+    /// <inheritdoc/>>
+    public ClientCacheState CacheState => this.evaluationServicesOrFakeImpl is EvaluationServices
+        ? this.cacheState
+        : ((IConfigCatClientSnapshot?)this.evaluationServicesOrFakeImpl)?.CacheState ?? ClientCacheState.NoFlagData;
 
-    /// <summary>
-    /// Returns the available setting keys.
-    /// </summary>
-    /// <remarks>
-    /// In case the client is configured to use flag override, this will also include the keys provided by the flag override.
-    /// </remarks>
-    /// <returns>The collection of keys.</returns>
+    /// <inheritdoc/>>
+    public IConfig? FetchedConfig => this.evaluationServicesOrFakeImpl is EvaluationServices
+        ? this.settings.RemoteConfig?.Config
+        : ((IConfigCatClientSnapshot?)this.evaluationServicesOrFakeImpl)?.FetchedConfig ?? null;
+
+    /// <inheritdoc/>>
     public IReadOnlyCollection<string> GetAllKeys()
     {
+        if (this.evaluationServicesOrFakeImpl is not EvaluationServices)
+        {
+            return this.evaluationServicesOrFakeImpl is not null
+                ? ((IConfigCatClientSnapshot)this.evaluationServicesOrFakeImpl).GetAllKeys()
+                : ArrayUtils.EmptyArray<string>();
+        }
+
         return this.settings.Value is { } settings ? settings.ReadOnlyKeys() : ArrayUtils.EmptyArray<string>();
     }
 
-    /// <summary>
-    /// Returns the value of a feature flag or setting identified by <paramref name="key"/> synchronously, based on the snapshot.
-    /// </summary>
-    /// <remarks>
-    /// It is important to provide an argument for the <paramref name="defaultValue"/> parameter, specifically for the <typeparamref name="T"/> generic type parameter,
-    /// that matches the type of the feature flag or setting you are evaluating.<br/>
-    /// Please refer to <see href="https://configcat.com/docs/sdk-reference/dotnet/#setting-type-mapping">this table</see> for the corresponding types.
-    /// </remarks>
-    /// <typeparam name="T">
-    /// The type of the value. Only the following types are allowed:
-    /// <see cref="string"/>, <see cref="bool"/>, <see cref="int"/>, <see cref="long"/>, <see cref="double"/> and <see cref="object"/> (both nullable and non-nullable).<br/>
-    /// The type must correspond to the setting type, otherwise <paramref name="defaultValue"/> will be returned.
-    /// </typeparam>
-    /// <param name="key">Key of the feature flag or setting.</param>
-    /// <param name="defaultValue">In case of failure, this value will be returned.</param>
-    /// <param name="user">The User Object to use for evaluating targeting rules and percentage options.</param>
-    /// <returns>The value of the feature flag or setting.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentException"><paramref name="key"/> is an empty string.</exception>
-    /// <exception cref="ArgumentException"><typeparamref name="T"/> is not an allowed type.</exception>
+    /// <inheritdoc/>>
     public T GetValue<T>(string key, T defaultValue, User? user = null)
     {
+        if (this.evaluationServicesOrFakeImpl is not EvaluationServices evaluationServices)
+        {
+            return this.evaluationServicesOrFakeImpl is not null
+                ? ((IConfigCatClientSnapshot)this.evaluationServicesOrFakeImpl).GetValue(key, defaultValue, user)
+                : defaultValue;
+        }
+
         if (key is null)
         {
             throw new ArgumentNullException(nameof(key));
@@ -91,42 +89,30 @@ public readonly struct ConfigCatClientSnapshot
         try
         {
             settings = this.settings;
-            evaluationDetails = ConfigEvaluator.Evaluate(settings.Value, key, defaultValue, user, settings.RemoteConfig, Logger);
+            evaluationDetails = evaluationServices.Evaluator.Evaluate(settings.Value, key, defaultValue, user, settings.RemoteConfig, evaluationServices.Logger);
             value = evaluationDetails.Value;
         }
         catch (Exception ex)
         {
-            Logger.SettingEvaluationError($"{nameof(ConfigCatClientSnapshot)}.{nameof(GetValue)}", key, nameof(defaultValue), defaultValue, ex);
+            evaluationServices.Logger.SettingEvaluationError($"{nameof(ConfigCatClientSnapshot)}.{nameof(GetValue)}", key, nameof(defaultValue), defaultValue, ex);
             evaluationDetails = EvaluationDetails.FromDefaultValue(key, defaultValue, fetchTime: settings.RemoteConfig?.TimeStamp, user, ex.Message, ex);
             value = defaultValue;
         }
 
-        Hooks.RaiseFlagEvaluated(evaluationDetails);
+        evaluationServices.Hooks.RaiseFlagEvaluated(evaluationDetails);
         return value;
     }
 
-    /// <summary>
-    /// Returns the value along with evaluation details of a feature flag or setting identified by <paramref name="key"/> synchronously, based on the snapshot.
-    /// </summary>
-    /// <remarks>
-    /// It is important to provide an argument for the <paramref name="defaultValue"/> parameter, specifically for the <typeparamref name="T"/> generic type parameter,
-    /// that matches the type of the feature flag or setting you are evaluating.<br/>
-    /// Please refer to <see href="https://configcat.com/docs/sdk-reference/dotnet/#setting-type-mapping">this table</see> for the corresponding types.
-    /// </remarks>
-    /// <typeparam name="T">
-    /// The type of the value. Only the following types are allowed:
-    /// <see cref="string"/>, <see cref="bool"/>, <see cref="int"/>, <see cref="long"/>, <see cref="double"/> and <see cref="object"/> (both nullable and non-nullable).<br/>
-    /// The type must correspond to the setting type, otherwise <paramref name="defaultValue"/> will be returned.
-    /// </typeparam>
-    /// <param name="key">Key of the feature flag or setting.</param>
-    /// <param name="defaultValue">In case of failure, this value will be returned.</param>
-    /// <param name="user">The User Object to use for evaluating targeting rules and percentage options.</param>
-    /// <returns>The value along with the details of evaluation of the feature flag or setting.</returns>
-    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentException"><paramref name="key"/> is an empty string.</exception>
-    /// <exception cref="ArgumentException"><typeparamref name="T"/> is not an allowed type.</exception>
+    /// <inheritdoc/>>
     public EvaluationDetails<T> GetValueDetails<T>(string key, T defaultValue, User? user = null)
     {
+        if (this.evaluationServicesOrFakeImpl is not EvaluationServices evaluationServices)
+        {
+            return this.evaluationServicesOrFakeImpl is not null
+                ? ((IConfigCatClientSnapshot)this.evaluationServicesOrFakeImpl).GetValueDetails(key, defaultValue, user)
+                : EvaluationDetails.FromDefaultValue(key, defaultValue, null, user, $"{nameof(GetValueDetails)} was called on the default instance of {nameof(ConfigCatClientSnapshot)}.");
+        }
+
         if (key is null)
         {
             throw new ArgumentNullException(nameof(key));
@@ -145,15 +131,15 @@ public readonly struct ConfigCatClientSnapshot
         try
         {
             settings = this.settings;
-            evaluationDetails = ConfigEvaluator.Evaluate(settings.Value, key, defaultValue, user, settings.RemoteConfig, Logger);
+            evaluationDetails = evaluationServices.Evaluator.Evaluate(settings.Value, key, defaultValue, user, settings.RemoteConfig, evaluationServices.Logger);
         }
         catch (Exception ex)
         {
-            Logger.SettingEvaluationError($"{nameof(ConfigCatClientSnapshot)}.{nameof(GetValueDetails)}", key, nameof(defaultValue), defaultValue, ex);
+            evaluationServices.Logger.SettingEvaluationError($"{nameof(ConfigCatClientSnapshot)}.{nameof(GetValueDetails)}", key, nameof(defaultValue), defaultValue, ex);
             evaluationDetails = EvaluationDetails.FromDefaultValue(key, defaultValue, fetchTime: settings.RemoteConfig?.TimeStamp, user, ex.Message, ex);
         }
 
-        Hooks.RaiseFlagEvaluated(evaluationDetails);
+        evaluationServices.Hooks.RaiseFlagEvaluated(evaluationDetails);
         return evaluationDetails;
     }
 }

--- a/src/ConfigCatClient/ConfigService/ClientCacheState.cs
+++ b/src/ConfigCatClient/ConfigService/ClientCacheState.cs
@@ -1,0 +1,27 @@
+namespace ConfigCat.Client;
+
+/// <summary>
+/// Specifies the possible states of the local cache.
+/// </summary>
+public enum ClientCacheState
+{
+    /// <summary>
+    /// No feature flag data is available in the local cache.
+    /// </summary>
+    NoFlagData,
+
+    /// <summary>
+    /// Feature flag data provided by local flag override is only available in the local cache.
+    /// </summary>
+    HasLocalOverrideFlagDataOnly,
+
+    /// <summary>
+    /// Out-of-date feature flag data downloaded from the remote server is available in the local cache.
+    /// </summary>
+    HasCachedFlagDataOnly,
+
+    /// <summary>
+    /// Up-to-date feature flag data downloaded from the remote server is available in the local cache.
+    /// </summary>
+    HasUpToDateFlagData,
+}

--- a/src/ConfigCatClient/ConfigService/IConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/IConfigService.cs
@@ -5,6 +5,10 @@ namespace ConfigCat.Client.ConfigService;
 
 internal interface IConfigService
 {
+    Task<ClientCacheState> ReadyTask { get; }
+
+    ProjectConfig GetInMemoryConfig();
+
     ProjectConfig GetConfig();
 
     ValueTask<ProjectConfig> GetConfigAsync(CancellationToken cancellationToken = default);
@@ -18,4 +22,6 @@ internal interface IConfigService
     void SetOnline();
 
     void SetOffline();
+
+    ClientCacheState GetCacheState(ProjectConfig config);
 }

--- a/src/ConfigCatClient/ConfigService/LazyLoadConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/LazyLoadConfigService.cs
@@ -14,7 +14,8 @@ internal sealed class LazyLoadConfigService : ConfigServiceBase, IConfigService
     {
         this.cacheTimeToLive = cacheTimeToLive;
 
-        ReadyTask = SetupClientReady(out _);
+        var initialCacheSyncUpTask = SyncUpWithCacheAsync(WaitForReadyCancellationToken);
+        ReadyTask = GetReadyTask(initialCacheSyncUpTask, async initialCacheSyncUpTask => GetCacheState(await initialCacheSyncUpTask.ConfigureAwait(false)));
     }
 
     public Task<ClientCacheState> ReadyTask { get; }

--- a/src/ConfigCatClient/ConfigService/ManualPollConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/ManualPollConfigService.cs
@@ -9,7 +9,8 @@ internal sealed class ManualPollConfigService : ConfigServiceBase, IConfigServic
     internal ManualPollConfigService(IConfigFetcher configFetcher, CacheParameters cacheParameters, LoggerWrapper logger, bool isOffline = false, SafeHooksWrapper hooks = default)
         : base(configFetcher, cacheParameters, logger, isOffline, hooks)
     {
-        ReadyTask = SetupClientReady(out _);
+        var initialCacheSyncUpTask = SyncUpWithCacheAsync(WaitForReadyCancellationToken);
+        ReadyTask = GetReadyTask(initialCacheSyncUpTask, async initialCacheSyncUpTask => GetCacheState(await initialCacheSyncUpTask.ConfigureAwait(false)));
     }
 
     public Task<ClientCacheState> ReadyTask { get; }

--- a/src/ConfigCatClient/ConfigService/ManualPollConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/ManualPollConfigService.cs
@@ -9,8 +9,10 @@ internal sealed class ManualPollConfigService : ConfigServiceBase, IConfigServic
     internal ManualPollConfigService(IConfigFetcher configFetcher, CacheParameters cacheParameters, LoggerWrapper logger, bool isOffline = false, SafeHooksWrapper hooks = default)
         : base(configFetcher, cacheParameters, logger, isOffline, hooks)
     {
-        hooks.RaiseClientReady();
+        ReadyTask = SetupClientReady(out _);
     }
+
+    public Task<ClientCacheState> ReadyTask { get; }
 
     public ProjectConfig GetConfig()
     {
@@ -20,5 +22,15 @@ internal sealed class ManualPollConfigService : ConfigServiceBase, IConfigServic
     public ValueTask<ProjectConfig> GetConfigAsync(CancellationToken cancellationToken = default)
     {
         return this.ConfigCache.GetAsync(base.CacheKey, cancellationToken);
+    }
+
+    public override ClientCacheState GetCacheState(ProjectConfig cachedConfig)
+    {
+        if (cachedConfig.IsEmpty)
+        {
+            return ClientCacheState.NoFlagData;
+        }
+
+        return ClientCacheState.HasCachedFlagDataOnly;
     }
 }

--- a/src/ConfigCatClient/ConfigService/NullConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/NullConfigService.cs
@@ -11,8 +11,12 @@ internal sealed class NullConfigService : IConfigService
     {
         this.logger = logger;
 
-        hooks.RaiseClientReady();
+        hooks.RaiseClientReady(ClientCacheState.HasLocalOverrideFlagDataOnly);
     }
+
+    public Task<ClientCacheState> ReadyTask => Task.FromResult(ClientCacheState.HasLocalOverrideFlagDataOnly);
+
+    public ProjectConfig GetInMemoryConfig() => ProjectConfig.Empty;
 
     public ProjectConfig GetConfig() => ProjectConfig.Empty;
 
@@ -30,4 +34,6 @@ internal sealed class NullConfigService : IConfigService
     {
         this.logger.ConfigServiceMethodHasNoEffectDueToOverrideBehavior(nameof(OverrideBehaviour.LocalOnly), nameof(SetOnline));
     }
+
+    public ClientCacheState GetCacheState(ProjectConfig config) => ClientCacheState.HasLocalOverrideFlagDataOnly;
 }

--- a/src/ConfigCatClient/Configuration/ConfigCatClientOptions.cs
+++ b/src/ConfigCatClient/Configuration/ConfigCatClientOptions.cs
@@ -114,7 +114,7 @@ public class ConfigCatClientOptions : IProvidesHooks
     }
 
     /// <inheritdoc/>
-    public event EventHandler? ClientReady
+    public event EventHandler<ClientReadyEventArgs>? ClientReady
     {
         add { this.hooks.ClientReady += value; }
         remove { this.hooks.ClientReady -= value; }

--- a/src/ConfigCatClient/Evaluation/RolloutEvaluator.cs
+++ b/src/ConfigCatClient/Evaluation/RolloutEvaluator.cs
@@ -958,7 +958,7 @@ internal sealed class RolloutEvaluator : IRolloutEvaluator
     private string[]? GetUserAttributeValueAsStringArray(string attributeName, object attributeValue, UserCondition condition, string key, out string? error)
     {
         if (attributeValue is string[] stringArray
-            || attributeValue is string json && (stringArray = json.DeserializeOrDefault<string[]>()!) is not null)
+            || attributeValue is string json && (stringArray = json.AsMemory().DeserializeOrDefault<string[]>()!) is not null)
         {
             if (!Array.Exists(stringArray, item => item is null))
             {

--- a/src/ConfigCatClient/Extensions/SerializationExtensions.cs
+++ b/src/ConfigCatClient/Extensions/SerializationExtensions.cs
@@ -23,8 +23,6 @@ internal static class SerializationExtensions
     };
 #endif
 
-    public static T? Deserialize<T>(this string json, bool tolerant = false) => json.AsMemory().Deserialize<T>(tolerant);
-
     // NOTE: It would be better to use ReadOnlySpan<char>, however when the full string is wrapped in a span, json.ToString() result in a copy of the string.
     // This is not the case with ReadOnlyMemory<char>, so we use that until support for .NET 4.5 support is dropped.
     public static T? Deserialize<T>(this ReadOnlyMemory<char> json, bool tolerant = false)
@@ -37,8 +35,6 @@ internal static class SerializationExtensions
         return JsonSerializer.Deserialize<T>(json.Span, tolerant ? TolerantSerializerOptions : null);
 #endif
     }
-
-    public static T? DeserializeOrDefault<T>(this string json, bool tolerant = false) => json.AsMemory().DeserializeOrDefault<T>(tolerant);
 
     public static T? DeserializeOrDefault<T>(this ReadOnlyMemory<char> json, bool tolerant = false)
     {

--- a/src/ConfigCatClient/Hooks/ClientReadyEventArgs.cs
+++ b/src/ConfigCatClient/Hooks/ClientReadyEventArgs.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace ConfigCat.Client;
+
+/// <summary>
+/// Provides data for the <see cref="ConfigCatClient.ClientReady"/> event.
+/// </summary>
+public class ClientReadyEventArgs : EventArgs
+{
+    internal ClientReadyEventArgs(ClientCacheState cacheState)
+    {
+        CacheState = cacheState;
+    }
+
+    /// <summary>
+    /// The state of the local cache at the time the initialization was completed.
+    /// </summary>
+    public ClientCacheState CacheState { get; }
+}

--- a/src/ConfigCatClient/Hooks/Hooks.cs
+++ b/src/ConfigCatClient/Hooks/Hooks.cs
@@ -34,15 +34,15 @@ internal class Hooks : IProvidesHooks
     }
 
     /// <inheritdoc/>
-    public event EventHandler? ClientReady
+    public event EventHandler<ClientReadyEventArgs>? ClientReady
     {
         add { this.eventHandlers.ClientReady += value; }
         remove { this.eventHandlers.ClientReady -= value; }
     }
 
-    internal void RaiseClientReady()
+    internal void RaiseClientReady(ClientCacheState cacheState)
     {
-        this.eventHandlers.ClientReady?.Invoke(this.client, EventArgs.Empty);
+        this.eventHandlers.ClientReady?.Invoke(this.client, new ClientReadyEventArgs(cacheState));
     }
 
     /// <inheritdoc/>
@@ -85,7 +85,7 @@ internal class Hooks : IProvidesHooks
     {
         private static void Noop(Delegate? _) { /* This method is for keeping SonarQube happy. */ }
 
-        public virtual EventHandler? ClientReady { get => null; set => Noop(value); }
+        public virtual EventHandler<ClientReadyEventArgs>? ClientReady { get => null; set => Noop(value); }
         public virtual EventHandler<FlagEvaluatedEventArgs>? FlagEvaluated { get => null; set => Noop(value); }
         public virtual EventHandler<ConfigChangedEventArgs>? ConfigChanged { get => null; set => Noop(value); }
         public virtual EventHandler<ConfigCatClientErrorEventArgs>? Error { get => null; set => Noop(value); }
@@ -93,7 +93,7 @@ internal class Hooks : IProvidesHooks
 
     private sealed class ActualEventHandlers : EventHandlers
     {
-        public override EventHandler? ClientReady { get; set; }
+        public override EventHandler<ClientReadyEventArgs>? ClientReady { get; set; }
         public override EventHandler<FlagEvaluatedEventArgs>? FlagEvaluated { get; set; }
         public override EventHandler<ConfigChangedEventArgs>? ConfigChanged { get; set; }
         public override EventHandler<ConfigCatClientErrorEventArgs>? Error { get; set; }

--- a/src/ConfigCatClient/Hooks/IProvidesHooks.cs
+++ b/src/ConfigCatClient/Hooks/IProvidesHooks.cs
@@ -10,7 +10,7 @@ public interface IProvidesHooks
     /// <summary>
     /// Occurs when the client is ready to provide the actual value of feature flags or settings.
     /// </summary>
-    event EventHandler? ClientReady;
+    event EventHandler<ClientReadyEventArgs>? ClientReady;
 
     /// <summary>
     /// Occurs after the value of a feature flag of setting has been evaluated.

--- a/src/ConfigCatClient/Hooks/SafeHooksWrapper.cs
+++ b/src/ConfigCatClient/Hooks/SafeHooksWrapper.cs
@@ -21,7 +21,7 @@ internal readonly struct SafeHooksWrapper
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public void RaiseClientReady() => Hooks.RaiseClientReady();
+    public void RaiseClientReady(ClientCacheState cacheState) => Hooks.RaiseClientReady(cacheState);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public void RaiseFlagEvaluated(EvaluationDetails evaluationDetails) => Hooks.RaiseFlagEvaluated(evaluationDetails);

--- a/src/ConfigCatClient/IConfigCatClient.cs
+++ b/src/ConfigCatClient/IConfigCatClient.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
+using ConfigCat.Client.Configuration;
 
 namespace ConfigCat.Client;
 
@@ -162,6 +164,27 @@ public interface IConfigCatClient : IProvidesHooks, IDisposable
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the refresh result.</returns>
     Task<RefreshResult> ForceRefreshAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Waits for the client to initialize (i.e. to raise the <see cref="IProvidesHooks.ClientReady"/> event).
+    /// </summary>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the state of the local cache at the time the initialization was completed.</returns>
+    Task<ClientCacheState> WaitForReadyAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Captures the current state of the client.
+    /// The resulting snapshot can be used to evaluate feature flags and settings based on the captured state synchronously,
+    /// without any underlying I/O-bound operations, which could block the executing thread for a longer period of time.
+    /// </summary>
+    /// <remarks>
+    /// The operation captures the in-memory stored config data. It does not attempt to update it by contacting the remote server.
+    /// It does not synchronize with the user-provided custom cache (see <see cref="ConfigCatClientOptions.ConfigCache"/>) either.<br/>
+    /// Therefore, it is recommended to use snapshots in conjunction with the Auto Polling mode, where the SDK automatically updates the local cache in the background.<br/>
+    /// For other polling modes, you'll need to manually initiate a cache refresh by invoking <see cref="ForceRefresh"/> or <see cref="ForceRefreshAsync"/>.
+    /// </remarks>
+    /// <returns>The snapshot object.</returns>
+    ConfigCatClientSnapshot Snapshot();
 
     /// <summary>
     /// Sets the default user.

--- a/src/ConfigCatClient/IConfigCatClient.cs
+++ b/src/ConfigCatClient/IConfigCatClient.cs
@@ -24,6 +24,11 @@ public interface IConfigCatClient : IProvidesHooks, IDisposable
     /// It is important to provide an argument for the <paramref name="defaultValue"/> parameter, specifically for the <typeparamref name="T"/> generic type parameter,
     /// that matches the type of the feature flag or setting you are evaluating.<br/>
     /// Please refer to <see href="https://configcat.com/docs/sdk-reference/dotnet/#setting-type-mapping">this table</see> for the corresponding types.
+    /// <para>
+    /// Please be aware that calling this method on a thread pool thread or the main UI thread is safe only when the client is set up to use Auto or Manual Polling and in-memory caching.
+    /// Otherwise execution may involve I/O-bound (e.g. network) operations, because of which the executing thread may be blocked for a longer period of time. This can result in an unresponsive application.
+    /// In the case of problematic setups, it is recommended to use either the async version of the method or snaphots (see <see cref="Snapshot"/>).
+    /// </para>
     /// </remarks>
     /// <typeparam name="T">
     /// The type of the value. Only the following types are allowed:
@@ -70,6 +75,11 @@ public interface IConfigCatClient : IProvidesHooks, IDisposable
     /// It is important to provide an argument for the <paramref name="defaultValue"/> parameter, specifically for the <typeparamref name="T"/> generic type parameter,
     /// that matches the type of the feature flag or setting you are evaluating.<br/>
     /// Please refer to <see href="https://configcat.com/docs/sdk-reference/dotnet/#setting-type-mapping">this table</see> for the corresponding types.
+    /// <para>
+    /// Please be aware that calling this method on a thread pool thread or the main UI thread is safe only when the client is set up to use Auto or Manual Polling and in-memory caching.
+    /// Otherwise execution may involve I/O-bound (e.g. network) operations, because of which the executing thread may be blocked for a longer period of time. This can result in an unresponsive application.
+    /// In the case of problematic setups, it is recommended to use either the async version of the method or snaphots (see <see cref="Snapshot"/>).
+    /// </para>
     /// </remarks>
     /// <typeparam name="T">
     /// The type of the value. Only the following types are allowed:
@@ -112,6 +122,13 @@ public interface IConfigCatClient : IProvidesHooks, IDisposable
     /// <summary>
     /// Returns all setting keys synchronously.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Please be aware that calling this method on a thread pool thread or the main UI thread is safe only when the client is set up to use Auto or Manual Polling and in-memory caching.
+    /// Otherwise execution may involve I/O-bound (e.g. network) operations, because of which the executing thread may be blocked for a longer period of time. This can result in an unresponsive application.
+    /// In the case of problematic setups, it is recommended to use either the async version of the method or snaphots (see <see cref="Snapshot"/>).
+    /// </para>
+    /// </remarks>
     /// <returns>The collection of keys.</returns>
     IReadOnlyCollection<string> GetAllKeys();
 
@@ -125,6 +142,13 @@ public interface IConfigCatClient : IProvidesHooks, IDisposable
     /// <summary>
     /// Returns the keys and values of all feature flags and settings synchronously.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Please be aware that calling this method on a thread pool thread or the main UI thread is safe only when the client is set up to use Auto or Manual Polling and in-memory caching.
+    /// Otherwise execution may involve I/O-bound (e.g. network) operations, because of which the executing thread may be blocked for a longer period of time. This can result in an unresponsive application.
+    /// In the case of problematic setups, it is recommended to use either the async version of the method or snaphots (see <see cref="Snapshot"/>).
+    /// </para>
+    /// </remarks>
     /// <param name="user">The User Object to use for evaluating targeting rules and percentage options.</param>
     /// <returns>The dictionary containing the keys and values.</returns>
     IReadOnlyDictionary<string, object?> GetAllValues(User? user = null);
@@ -140,6 +164,13 @@ public interface IConfigCatClient : IProvidesHooks, IDisposable
     /// <summary>
     /// Returns the values along with evaluation details of all feature flags and settings synchronously.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Please be aware that calling this method on a thread pool thread or the main UI thread is safe only when the client is set up to use Auto or Manual Polling and in-memory caching.
+    /// Otherwise execution may involve I/O-bound (e.g. network) operations, because of which the executing thread may be blocked for a longer period of time. This can result in an unresponsive application.
+    /// In the case of problematic setups, it is recommended to use either the async version of the method or snaphots (see <see cref="Snapshot"/>).
+    /// </para>
+    /// </remarks>
     /// <param name="user">The User Object to use for evaluating targeting rules and percentage options.</param>
     /// <returns>The list of values along with evaluation details.</returns>
     IReadOnlyList<EvaluationDetails> GetAllValueDetails(User? user = null);
@@ -155,6 +186,13 @@ public interface IConfigCatClient : IProvidesHooks, IDisposable
     /// <summary>
     /// Refreshes the locally cached config by fetching the latest version from the remote server synchronously.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Please be aware that calling this method on a thread pool thread or the main UI thread is not safe as
+    /// execution involves I/O-bound (e.g. network) operations, because of which the executing thread may be blocked for a longer period of time. This can result in an unresponsive application.
+    /// In the case of problematic setups, it is recommended to either use the async version of the method or call the method on a dedicated background thread.
+    /// </para>
+    /// </remarks>
     /// <returns>The refresh result.</returns>
     RefreshResult ForceRefresh();
 

--- a/src/ConfigCatClient/IConfigCatClient.cs
+++ b/src/ConfigCatClient/IConfigCatClient.cs
@@ -41,6 +41,7 @@ public interface IConfigCatClient : IProvidesHooks, IDisposable
     /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="key"/> is an empty string.</exception>
     /// <exception cref="ArgumentException"><typeparamref name="T"/> is not an allowed type.</exception>
+    [Obsolete("This method may lead to an unresponsive application (see remarks), thus it will be removed from the public API in a future major version. Please use either the async version of the method or snaphots.")]
     T GetValue<T>(string key, T defaultValue, User? user = null);
 
     /// <summary>
@@ -92,6 +93,7 @@ public interface IConfigCatClient : IProvidesHooks, IDisposable
     /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException"><paramref name="key"/> is an empty string.</exception>
     /// <exception cref="ArgumentException"><typeparamref name="T"/> is not an allowed type.</exception>
+    [Obsolete("This method may lead to an unresponsive application (see remarks), thus it will be removed from the public API in a future major version. Please use either the async version of the method or snaphots.")]
     EvaluationDetails<T> GetValueDetails<T>(string key, T defaultValue, User? user = null);
 
     /// <summary>
@@ -129,6 +131,7 @@ public interface IConfigCatClient : IProvidesHooks, IDisposable
     /// </para>
     /// </remarks>
     /// <returns>The collection of keys.</returns>
+    [Obsolete("This method may lead to an unresponsive application (see remarks), thus it will be removed from the public API in a future major version. Please use either the async version of the method or snaphots.")]
     IReadOnlyCollection<string> GetAllKeys();
 
     /// <summary>
@@ -150,6 +153,7 @@ public interface IConfigCatClient : IProvidesHooks, IDisposable
     /// </remarks>
     /// <param name="user">The User Object to use for evaluating targeting rules and percentage options.</param>
     /// <returns>The dictionary containing the keys and values.</returns>
+    [Obsolete("This method may lead to an unresponsive application (see remarks), thus it will be removed from the public API in a future major version. Please use either the async version of the method or snaphots.")]
     IReadOnlyDictionary<string, object?> GetAllValues(User? user = null);
 
     /// <summary>
@@ -172,6 +176,7 @@ public interface IConfigCatClient : IProvidesHooks, IDisposable
     /// </remarks>
     /// <param name="user">The User Object to use for evaluating targeting rules and percentage options.</param>
     /// <returns>The list of values along with evaluation details.</returns>
+    [Obsolete("This method may lead to an unresponsive application (see remarks), thus it will be removed from the public API in a future major version. Please use either the async version of the method or snaphots.")]
     IReadOnlyList<EvaluationDetails> GetAllValueDetails(User? user = null);
 
     /// <summary>
@@ -193,6 +198,7 @@ public interface IConfigCatClient : IProvidesHooks, IDisposable
     /// </para>
     /// </remarks>
     /// <returns>The refresh result.</returns>
+    [Obsolete("This method may lead to an unresponsive application (see remarks), thus it will be removed from the public API in a future major version. Please use either the async version of the method or snaphots.")]
     RefreshResult ForceRefresh();
 
     /// <summary>

--- a/src/ConfigCatClient/IConfigCatClient.cs
+++ b/src/ConfigCatClient/IConfigCatClient.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using ConfigCat.Client.Configuration;

--- a/src/ConfigCatClient/IConfigCatClientSnapshot.cs
+++ b/src/ConfigCatClient/IConfigCatClientSnapshot.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ConfigCat.Client;
+
+/// <summary>
+/// Defines the public interface of the <see cref="ConfigCatClientSnapshot"/> struct.
+/// </summary>
+public interface IConfigCatClientSnapshot
+{
+    /// <summary>
+    /// The state of the local cache at the time the snapshot was created.
+    /// </summary>
+    ClientCacheState CacheState { get; }
+
+    /// <summary>
+    /// The latest config which has been fetched from the remote server.
+    /// </summary>
+    IConfig? FetchedConfig { get; }
+
+    /// <summary>
+    /// Returns the available setting keys.
+    /// </summary>
+    /// <remarks>
+    /// In case the client is configured to use flag override, this will also include the keys provided by the flag override.
+    /// </remarks>
+    /// <returns>The collection of keys.</returns>
+    IReadOnlyCollection<string> GetAllKeys();
+
+    /// <summary>
+    /// Returns the value of a feature flag or setting identified by <paramref name="key"/> synchronously, based on the snapshot.
+    /// </summary>
+    /// <remarks>
+    /// It is important to provide an argument for the <paramref name="defaultValue"/> parameter, specifically for the <typeparamref name="T"/> generic type parameter,
+    /// that matches the type of the feature flag or setting you are evaluating.<br/>
+    /// Please refer to <see href="https://configcat.com/docs/sdk-reference/dotnet/#setting-type-mapping">this table</see> for the corresponding types.
+    /// </remarks>
+    /// <typeparam name="T">
+    /// The type of the value. Only the following types are allowed:
+    /// <see cref="string"/>, <see cref="bool"/>, <see cref="int"/>, <see cref="long"/>, <see cref="double"/> and <see cref="object"/> (both nullable and non-nullable).<br/>
+    /// The type must correspond to the setting type, otherwise <paramref name="defaultValue"/> will be returned.
+    /// </typeparam>
+    /// <param name="key">Key of the feature flag or setting.</param>
+    /// <param name="defaultValue">In case of failure, this value will be returned.</param>
+    /// <param name="user">The User Object to use for evaluating targeting rules and percentage options.</param>
+    /// <returns>The value of the feature flag or setting.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="key"/> is an empty string.</exception>
+    /// <exception cref="ArgumentException"><typeparamref name="T"/> is not an allowed type.</exception>
+    T GetValue<T>(string key, T defaultValue, User? user = null);
+
+    /// <summary>
+    /// Returns the value along with evaluation details of a feature flag or setting identified by <paramref name="key"/> synchronously, based on the snapshot.
+    /// </summary>
+    /// <remarks>
+    /// It is important to provide an argument for the <paramref name="defaultValue"/> parameter, specifically for the <typeparamref name="T"/> generic type parameter,
+    /// that matches the type of the feature flag or setting you are evaluating.<br/>
+    /// Please refer to <see href="https://configcat.com/docs/sdk-reference/dotnet/#setting-type-mapping">this table</see> for the corresponding types.
+    /// </remarks>
+    /// <typeparam name="T">
+    /// The type of the value. Only the following types are allowed:
+    /// <see cref="string"/>, <see cref="bool"/>, <see cref="int"/>, <see cref="long"/>, <see cref="double"/> and <see cref="object"/> (both nullable and non-nullable).<br/>
+    /// The type must correspond to the setting type, otherwise <paramref name="defaultValue"/> will be returned.
+    /// </typeparam>
+    /// <param name="key">Key of the feature flag or setting.</param>
+    /// <param name="defaultValue">In case of failure, this value will be returned.</param>
+    /// <param name="user">The User Object to use for evaluating targeting rules and percentage options.</param>
+    /// <returns>The value along with the details of evaluation of the feature flag or setting.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="key"/> is an empty string.</exception>
+    /// <exception cref="ArgumentException"><typeparamref name="T"/> is not an allowed type.</exception>
+    EvaluationDetails<T> GetValueDetails<T>(string key, T defaultValue, User? user = null);
+}

--- a/src/ConfigCatClient/Override/LocalFileDataSource.cs
+++ b/src/ConfigCatClient/Override/LocalFileDataSource.cs
@@ -104,7 +104,7 @@ internal sealed class LocalFileDataSource : IOverrideDataSource, IDisposable
                 try
                 {
                     var content = File.ReadAllText(this.fullPath);
-                    var simplified = content.DeserializeOrDefault<SimplifiedConfig>(tolerant: true);
+                    var simplified = content.AsMemory().DeserializeOrDefault<SimplifiedConfig>(tolerant: true);
                     if (simplified?.Entries is not null)
                     {
                         this.overrideValues = simplified.Entries.ToDictionary(kv => kv.Key, kv => kv.Value.ToSetting());


### PR DESCRIPTION
### Describe the purpose of your pull request

Adds an API which makes it possible to synchronously evaluate feature flags/settings without block waiting for potential underlying I/O operations: consumers can create a snapshot of the client by `IConfigCatClient.Snapshot()`, which captures the client's state (including the latest config fetched) at that point, then, using the returned object, they can execute non-blocking synchronous evaluation operations.

Also
* adds a parameter named `CacheState` to the event args of the `ClientReady` hook, by means of which consumers can get information about the initialization state of the client,
* adds warnings to the XML documentation of the blocking synchronous methods of `IConfigCatClient`.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
