### PR TITLE
Error reporting improvements

### DIFF
--- a/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
+++ b/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
@@ -1040,6 +1040,7 @@ public class ConfigCatClientTests
         this.configServiceMock.Verify(m => m.RefreshConfigAsync(It.IsAny<CancellationToken>()), Times.Once);
 
         Assert.IsTrue(result.IsSuccess);
+        Assert.AreEqual(RefreshErrorCode.None, result.ErrorCode);
         Assert.IsNull(result.ErrorMessage);
         Assert.IsNull(result.ErrorException);
     }
@@ -1065,6 +1066,7 @@ public class ConfigCatClientTests
         this.configServiceMock.Verify(m => m.RefreshConfig(), Times.Once);
 
         Assert.IsTrue(result.IsSuccess);
+        Assert.AreEqual(RefreshErrorCode.None, result.ErrorCode);
         Assert.IsNull(result.ErrorMessage);
         Assert.IsNull(result.ErrorException);
     }
@@ -1090,6 +1092,7 @@ public class ConfigCatClientTests
         this.configServiceMock.Verify(m => m.RefreshConfigAsync(It.IsAny<CancellationToken>()), Times.Once);
 
         Assert.IsTrue(result.IsSuccess);
+        Assert.AreEqual(RefreshErrorCode.None, result.ErrorCode);
         Assert.IsNull(result.ErrorMessage);
         Assert.IsNull(result.ErrorException);
     }
@@ -1117,6 +1120,7 @@ public class ConfigCatClientTests
         this.loggerMock.Verify(m => m.Log(LogLevel.Error, It.IsAny<LogEventId>(), ref It.Ref<FormattableLogMessage>.IsAny, It.IsAny<Exception>()), Times.Once);
 
         Assert.IsFalse(result.IsSuccess);
+        Assert.AreEqual(RefreshErrorCode.UnexpectedError, result.ErrorCode);
         Assert.AreEqual(exception.Message, result.ErrorMessage);
         Assert.AreSame(exception, result.ErrorException);
     }
@@ -1144,6 +1148,7 @@ public class ConfigCatClientTests
         this.loggerMock.Verify(m => m.Log(LogLevel.Error, It.IsAny<LogEventId>(), ref It.Ref<FormattableLogMessage>.IsAny, It.IsAny<Exception>()), Times.Once);
 
         Assert.IsFalse(result.IsSuccess);
+        Assert.AreEqual(RefreshErrorCode.UnexpectedError, result.ErrorCode);
         Assert.AreEqual(exception.Message, result.ErrorMessage);
         Assert.AreSame(exception, result.ErrorException);
     }
@@ -1599,6 +1604,7 @@ public class ConfigCatClientTests
             Assert.AreEqual(etag2, ParseETagAsInt32((await configService.GetConfigAsync()).HttpETag));
 
             Assert.IsTrue(refreshResult.IsSuccess);
+            Assert.AreEqual(RefreshErrorCode.None, refreshResult.ErrorCode);
             Assert.IsNull(refreshResult.ErrorMessage);
             Assert.IsNull(refreshResult.ErrorException);
 
@@ -1615,6 +1621,7 @@ public class ConfigCatClientTests
             Assert.AreEqual(etag3, ParseETagAsInt32((await configService.GetConfigAsync()).HttpETag));
 
             Assert.IsTrue(refreshResult.IsSuccess);
+            Assert.AreEqual(RefreshErrorCode.None, refreshResult.ErrorCode);
             Assert.IsNull(refreshResult.ErrorMessage);
             Assert.IsNull(refreshResult.ErrorException);
         }
@@ -1729,6 +1736,7 @@ public class ConfigCatClientTests
             Assert.AreEqual(etag1, ParseETagAsInt32((await configService.GetConfigAsync()).HttpETag));
 
             Assert.IsFalse(refreshResult.IsSuccess);
+            Assert.AreEqual(RefreshErrorCode.OfflineClient, refreshResult.ErrorCode);
             StringAssert.Contains(refreshResult.ErrorMessage, "offline mode");
             Assert.IsNull(refreshResult.ErrorException);
 
@@ -1743,6 +1751,7 @@ public class ConfigCatClientTests
             Assert.AreEqual(etag1, ParseETagAsInt32((await configService.GetConfigAsync()).HttpETag));
 
             Assert.IsFalse(refreshResult.IsSuccess);
+            Assert.AreEqual(RefreshErrorCode.OfflineClient, refreshResult.ErrorCode);
             StringAssert.Contains(refreshResult.ErrorMessage, "offline mode");
             Assert.IsNull(refreshResult.ErrorException);
         }
@@ -1776,7 +1785,7 @@ public class ConfigCatClientTests
         var onFetch = (ProjectConfig latestConfig, CancellationToken _) =>
         {
             var logMessage = loggerWrapper.FetchFailedDueToUnexpectedError(errorException);
-            return FetchResult.Failure(latestConfig, errorMessage: logMessage.InvariantFormattedMessage, errorException: errorException);
+            return FetchResult.Failure(latestConfig, RefreshErrorCode.HttpRequestFailure, errorMessage: logMessage.InvariantFormattedMessage, errorException: errorException);
         };
         this.fetcherMock.Setup(m => m.FetchAsync(It.IsAny<ProjectConfig>(), It.IsAny<CancellationToken>())).ReturnsAsync(onFetch);
 

--- a/src/ConfigCat.Client.Tests/ConfigServiceTests.cs
+++ b/src/ConfigCat.Client.Tests/ConfigServiceTests.cs
@@ -750,7 +750,7 @@ public class ConfigServiceTests
         cache.Set(null!, cachedPc);
 
         this.fetcherMock.Setup(m => m.FetchAsync(cachedPc, It.IsAny<CancellationToken>())).ReturnsAsync(
-            failure ? FetchResult.Failure(fetchedPc, "network error") : FetchResult.NotModified(fetchedPc));
+            failure ? FetchResult.Failure(fetchedPc, RefreshErrorCode.HttpRequestFailure, "network error") : FetchResult.NotModified(fetchedPc));
 
         var config = PollingModes.AutoPoll(pollInterval, maxInitWaitTime);
         var service = new AutoPollConfigService(config,

--- a/src/ConfigCat.Client.Tests/ConfigV2EvaluationTests.cs
+++ b/src/ConfigCat.Client.Tests/ConfigV2EvaluationTests.cs
@@ -233,7 +233,7 @@ public class ConfigV2EvaluationTests : EvaluationTestsBase
         var logger = new Mock<IConfigCatLogger>().Object.AsWrapper();
         var evaluator = new RolloutEvaluator(logger);
 
-        var ex = Assert.ThrowsException<InvalidOperationException>(() => evaluator.Evaluate<object?>(config!.Settings, key, defaultValue: null, user: null, remoteConfig: null, logger));
+        var ex = Assert.ThrowsException<InvalidConfigModelException>(() => evaluator.Evaluate<object?>(config!.Settings, key, defaultValue: null, user: null, remoteConfig: null, logger));
 
         StringAssert.Contains(ex.Message, "Circular dependency detected");
         StringAssert.Contains(ex.Message, dependencyCycle);

--- a/src/ConfigCat.Client.Tests/EvaluationTestsBase.cs
+++ b/src/ConfigCat.Client.Tests/EvaluationTestsBase.cs
@@ -112,7 +112,7 @@ public abstract class EvaluationTestsBase
             this.logger,
         };
 
-        var ex = Assert.ThrowsException<InvalidOperationException>(() =>
+        var ex = Assert.ThrowsException<EvaluationErrorException>(() =>
         {
             try { EvaluateMethodDefinition.MakeGenericMethod(settingClrType).Invoke(null, args); }
             catch (TargetInvocationException ex) { throw ex.InnerException!; }

--- a/src/ConfigCat.Client.Tests/HttpConfigFetcherTests.cs
+++ b/src/ConfigCat.Client.Tests/HttpConfigFetcherTests.cs
@@ -50,7 +50,7 @@ public class HttpConfigFetcherTests
     }
 
     [TestMethod]
-    public async Task HttpConfigFetcher_ResponseHttpCodeIsUnexpected_ShouldReturnsPassedConfig()
+    public async Task HttpConfigFetcher_ResponseHttpCodeIsUnexpected_ShouldReturnPassedConfig()
     {
         // Arrange
 
@@ -68,6 +68,7 @@ public class HttpConfigFetcherTests
         // Assert
 
         Assert.IsTrue(actual.IsFailure);
+        Assert.AreEqual(RefreshErrorCode.InvalidSdkKey, actual.ErrorCode);
         Assert.IsNotNull(actual.ErrorMessage);
         Assert.IsNull(actual.ErrorException);
         Assert.AreNotSame(lastConfig, actual.Config);
@@ -96,6 +97,7 @@ public class HttpConfigFetcherTests
         // Assert
 
         Assert.IsTrue(actual.IsFailure);
+        Assert.AreEqual(RefreshErrorCode.HttpRequestFailure, actual.ErrorCode);
         Assert.IsNotNull(actual.ErrorMessage);
         Assert.AreSame(exception, actual.ErrorException);
         Assert.AreEqual(lastConfig, actual.Config);

--- a/src/ConfigCat.Client.Tests/OverrideTests.cs
+++ b/src/ConfigCat.Client.Tests/OverrideTests.cs
@@ -266,6 +266,7 @@ public class OverrideTests
         Assert.IsTrue(client.GetValue("nonexisting", false));
 
         Assert.IsFalse(refreshResult.IsSuccess);
+        Assert.AreEqual(RefreshErrorCode.LocalOnlyClient, refreshResult.ErrorCode);
         StringAssert.Contains(refreshResult.ErrorMessage, nameof(OverrideBehaviour.LocalOnly));
         Assert.IsNull(refreshResult.ErrorException);
     }
@@ -333,6 +334,7 @@ public class OverrideTests
         Assert.IsTrue(client.GetValue("nonexisting", false));
 
         Assert.IsFalse(refreshResult.IsSuccess);
+        Assert.AreEqual(RefreshErrorCode.LocalOnlyClient, refreshResult.ErrorCode);
         StringAssert.Contains(refreshResult.ErrorMessage, nameof(OverrideBehaviour.LocalOnly));
         Assert.IsNull(refreshResult.ErrorException);
     }

--- a/src/ConfigCat.Client.Tests/OverrideTests.cs
+++ b/src/ConfigCat.Client.Tests/OverrideTests.cs
@@ -4,8 +4,8 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using ConfigCat.Client.Evaluation;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
 
 #if USE_NEWTONSOFT_JSON
 using JsonValue = Newtonsoft.Json.Linq.JValue;
@@ -576,14 +576,37 @@ public class OverrideTests
             options.FlagOverrides = FlagOverrides.LocalDictionary(dictionary, OverrideBehaviour.LocalOnly);
         });
 
-        var method = typeof(IConfigCatClient).GetMethod(nameof(IConfigCatClient.GetValue))!
+        var method = typeof(IConfigCatClient).GetMethod(nameof(IConfigCatClient.GetValueDetails))!
             .GetGenericMethodDefinition()
             .MakeGenericMethod(defaultValue.GetType());
 
-        var actualEvaluatedValue = method.Invoke(client, new[] { key, defaultValue, null });
+        var actualEvaluatedValueDetails = (EvaluationDetails)method.Invoke(client, new[] { key, defaultValue, null })!;
+        var actualEvaluatedValue = actualEvaluatedValueDetails.Value;
         var actualEvaluatedValues = client.GetAllValues(user: null);
 
         Assert.AreEqual(expectedEvaluatedValue, actualEvaluatedValue);
+        if (!defaultValue.Equals(expectedEvaluatedValue))
+        {
+            Assert.IsFalse(actualEvaluatedValueDetails.IsDefaultValue);
+            Assert.AreEqual(EvaluationErrorCode.None, actualEvaluatedValueDetails.ErrorCode);
+            Assert.IsNull(actualEvaluatedValueDetails.ErrorMessage);
+            Assert.IsNull(actualEvaluatedValueDetails.ErrorException);
+        }
+        else
+        {
+            Assert.IsTrue(actualEvaluatedValueDetails.IsDefaultValue);
+            Assert.IsNotNull(actualEvaluatedValueDetails.ErrorMessage);
+            if (overrideValue.ToSettingValue(out _).HasUnsupportedValue)
+            {
+                Assert.AreEqual(EvaluationErrorCode.InvalidConfigModel, actualEvaluatedValueDetails.ErrorCode);
+                Assert.IsInstanceOfType(actualEvaluatedValueDetails.ErrorException, typeof(InvalidConfigModelException));
+            }
+            else
+            {
+                Assert.AreEqual(EvaluationErrorCode.SettingValueTypeMismatch, actualEvaluatedValueDetails.ErrorCode);
+                Assert.IsInstanceOfType(actualEvaluatedValueDetails.ErrorException, typeof(EvaluationErrorException));
+            }
+        }
 
         overrideValue.ToSettingValue(out var overrideValueSettingType);
         var expectedEvaluatedValues = new KeyValuePair<string, object?>[]
@@ -638,14 +661,41 @@ public class OverrideTests
                 options.FlagOverrides = FlagOverrides.LocalFile(filePath, autoReload: false, OverrideBehaviour.LocalOnly);
             });
 
-            var method = typeof(IConfigCatClient).GetMethod(nameof(IConfigCatClient.GetValue))!
+            var method = typeof(IConfigCatClient).GetMethod(nameof(IConfigCatClient.GetValueDetails))!
                 .GetGenericMethodDefinition()
                 .MakeGenericMethod(defaultValue.GetType());
 
-            var actualEvaluatedValue = method.Invoke(client, new[] { key, defaultValue, null });
+            var actualEvaluatedValueDetails = (EvaluationDetails)method.Invoke(client, new[] { key, defaultValue, null })!;
+            var actualEvaluatedValue = actualEvaluatedValueDetails.Value;
             var actualEvaluatedValues = client.GetAllValues(user: null);
 
             Assert.AreEqual(expectedEvaluatedValue, actualEvaluatedValue);
+            if (!defaultValue.Equals(expectedEvaluatedValue))
+            {
+                Assert.IsFalse(actualEvaluatedValueDetails.IsDefaultValue);
+                Assert.AreEqual(EvaluationErrorCode.None, actualEvaluatedValueDetails.ErrorCode);
+                Assert.IsNull(actualEvaluatedValueDetails.ErrorMessage);
+                Assert.IsNull(actualEvaluatedValueDetails.ErrorException);
+            }
+            else
+            {
+                Assert.IsTrue(actualEvaluatedValueDetails.IsDefaultValue);
+                Assert.IsNotNull(actualEvaluatedValueDetails.ErrorMessage);
+#if USE_NEWTONSOFT_JSON
+                if (overrideValue is not JsonValue overrideJsonValue || overrideJsonValue.ToSettingValue(out _).HasUnsupportedValue)
+#else
+                if (overrideValue.ToSettingValue(out _).HasUnsupportedValue)
+#endif
+                {
+                    Assert.AreEqual(EvaluationErrorCode.InvalidConfigModel, actualEvaluatedValueDetails.ErrorCode);
+                    Assert.IsInstanceOfType(actualEvaluatedValueDetails.ErrorException, typeof(InvalidConfigModelException));
+                }
+                else
+                {
+                    Assert.AreEqual(EvaluationErrorCode.SettingValueTypeMismatch, actualEvaluatedValueDetails.ErrorCode);
+                    Assert.IsInstanceOfType(actualEvaluatedValueDetails.ErrorException, typeof(EvaluationErrorException));
+                }
+            }
 
             var unwrappedOverrideValue = overrideValue is JsonValue jsonValue
                 ? jsonValue.ToSettingValue(out var overrideValueSettingType)

--- a/src/ConfigCatClient/ConfigCatClient.cs
+++ b/src/ConfigCatClient/ConfigCatClient.cs
@@ -594,7 +594,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         catch (Exception ex)
         {
             this.logger.ForceRefreshError(nameof(ForceRefresh), ex);
-            return RefreshResult.Failure(ex.Message, ex);
+            return RefreshResult.Failure(RefreshErrorCode.UnexpectedError, ex.Message, ex);
         }
     }
 
@@ -612,7 +612,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         catch (Exception ex)
         {
             this.logger.ForceRefreshError(nameof(ForceRefreshAsync), ex);
-            return RefreshResult.Failure(ex.Message, ex);
+            return RefreshResult.Failure(RefreshErrorCode.UnexpectedError, ex.Message, ex);
         }
     }
 

--- a/src/ConfigCatClient/ConfigCatClient.cs
+++ b/src/ConfigCatClient/ConfigCatClient.cs
@@ -282,7 +282,8 @@ public sealed class ConfigCatClient : IConfigCatClient
         catch (Exception ex)
         {
             this.logger.SettingEvaluationError(nameof(GetValue), key, nameof(defaultValue), defaultValue, ex);
-            evaluationDetails = EvaluationDetails.FromDefaultValue(key, defaultValue, fetchTime: settings.RemoteConfig?.TimeStamp, user, ex.Message, ex);
+            evaluationDetails = EvaluationDetails.FromDefaultValue(key, defaultValue, fetchTime: settings.RemoteConfig?.TimeStamp, user,
+                ex.Message, ex, RolloutEvaluatorExtensions.GetErrorCode(ex));
             value = defaultValue;
         }
 
@@ -322,7 +323,8 @@ public sealed class ConfigCatClient : IConfigCatClient
         catch (Exception ex)
         {
             this.logger.SettingEvaluationError(nameof(GetValueAsync), key, nameof(defaultValue), defaultValue, ex);
-            evaluationDetails = EvaluationDetails.FromDefaultValue(key, defaultValue, fetchTime: settings.RemoteConfig?.TimeStamp, user, ex.Message, ex);
+            evaluationDetails = EvaluationDetails.FromDefaultValue(key, defaultValue, fetchTime: settings.RemoteConfig?.TimeStamp, user,
+                ex.Message, ex, RolloutEvaluatorExtensions.GetErrorCode(ex));
             value = defaultValue;
         }
 
@@ -356,7 +358,8 @@ public sealed class ConfigCatClient : IConfigCatClient
         catch (Exception ex)
         {
             this.logger.SettingEvaluationError(nameof(GetValueDetails), key, nameof(defaultValue), defaultValue, ex);
-            evaluationDetails = EvaluationDetails.FromDefaultValue(key, defaultValue, fetchTime: settings.RemoteConfig?.TimeStamp, user, ex.Message, ex);
+            evaluationDetails = EvaluationDetails.FromDefaultValue(key, defaultValue, fetchTime: settings.RemoteConfig?.TimeStamp, user,
+                ex.Message, ex, RolloutEvaluatorExtensions.GetErrorCode(ex));
         }
 
         this.hooks.RaiseFlagEvaluated(evaluationDetails);
@@ -393,7 +396,8 @@ public sealed class ConfigCatClient : IConfigCatClient
         catch (Exception ex)
         {
             this.logger.SettingEvaluationError(nameof(GetValueDetailsAsync), key, nameof(defaultValue), defaultValue, ex);
-            evaluationDetails = EvaluationDetails.FromDefaultValue(key, defaultValue, fetchTime: settings.RemoteConfig?.TimeStamp, user, ex.Message, ex);
+            evaluationDetails = EvaluationDetails.FromDefaultValue(key, defaultValue, fetchTime: settings.RemoteConfig?.TimeStamp, user,
+                ex.Message, ex, RolloutEvaluatorExtensions.GetErrorCode(ex));
         }
 
         this.hooks.RaiseFlagEvaluated(evaluationDetails);

--- a/src/ConfigCatClient/ConfigCatClient.cs
+++ b/src/ConfigCatClient/ConfigCatClient.cs
@@ -745,6 +745,13 @@ public sealed class ConfigCatClient : IConfigCatClient
     }
 
     /// <inheritdoc/>
+    public event EventHandler<ConfigFetchedEventArgs>? ConfigFetched
+    {
+        add { this.hooks.ConfigFetched += value; }
+        remove { this.hooks.ConfigFetched -= value; }
+    }
+
+    /// <inheritdoc/>
     public event EventHandler<ConfigChangedEventArgs>? ConfigChanged
     {
         add { this.hooks.ConfigChanged += value; }

--- a/src/ConfigCatClient/ConfigService/AutoPollConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/AutoPollConfigService.cs
@@ -146,10 +146,10 @@ internal sealed class AutoPollConfigService : ConfigServiceBase, IConfigService
         return await this.ConfigCache.GetAsync(base.CacheKey, cancellationToken).ConfigureAwait(false);
     }
 
-    protected override void OnConfigFetched(ProjectConfig newConfig)
+    protected override void OnConfigFetched(in FetchResult fetchResult, bool isInitiatedByUser)
     {
-        base.OnConfigFetched(newConfig);
         SignalInitialization();
+        base.OnConfigFetched(fetchResult, isInitiatedByUser);
     }
 
     protected override void SetOnlineCoreSynchronized()
@@ -214,7 +214,7 @@ internal sealed class AutoPollConfigService : ConfigServiceBase, IConfigService
             {
                 if (!IsOffline)
                 {
-                    await RefreshConfigCoreAsync(latestConfig, cancellationToken).ConfigureAwait(false);
+                    await RefreshConfigCoreAsync(latestConfig, isInitiatedByUser: false, cancellationToken).ConfigureAwait(false);
                 }
             }
             else
@@ -227,7 +227,7 @@ internal sealed class AutoPollConfigService : ConfigServiceBase, IConfigService
             if (!IsOffline)
             {
                 var latestConfig = await this.ConfigCache.GetAsync(base.CacheKey, cancellationToken).ConfigureAwait(false);
-                await RefreshConfigCoreAsync(latestConfig, cancellationToken).ConfigureAwait(false);
+                await RefreshConfigCoreAsync(latestConfig, isInitiatedByUser: false, cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/src/ConfigCatClient/ConfigService/ConfigServiceBase.cs
+++ b/src/ConfigCatClient/ConfigService/ConfigServiceBase.cs
@@ -74,7 +74,7 @@ internal abstract class ConfigServiceBase : IDisposable
         if (!IsOffline)
         {
             var latestConfig = this.ConfigCache.Get(this.CacheKey);
-            var configWithFetchResult = RefreshConfigCore(latestConfig);
+            var configWithFetchResult = RefreshConfigCore(latestConfig, isInitiatedByUser: true);
             return RefreshResult.From(configWithFetchResult.Item2);
         }
         else
@@ -84,7 +84,7 @@ internal abstract class ConfigServiceBase : IDisposable
         }
     }
 
-    protected ConfigWithFetchResult RefreshConfigCore(ProjectConfig latestConfig)
+    protected ConfigWithFetchResult RefreshConfigCore(ProjectConfig latestConfig, bool isInitiatedByUser)
     {
         var fetchResult = this.ConfigFetcher.Fetch(latestConfig);
 
@@ -96,11 +96,11 @@ internal abstract class ConfigServiceBase : IDisposable
             latestConfig = fetchResult.Config;
         }
 
-        OnConfigFetched(fetchResult.Config);
+        OnConfigFetched(fetchResult, isInitiatedByUser);
 
         if (fetchResult.IsSuccess)
         {
-            OnConfigChanged(fetchResult.Config);
+            OnConfigChanged(fetchResult);
         }
 
         return new ConfigWithFetchResult(latestConfig, fetchResult);
@@ -111,7 +111,7 @@ internal abstract class ConfigServiceBase : IDisposable
         if (!IsOffline)
         {
             var latestConfig = await this.ConfigCache.GetAsync(this.CacheKey, cancellationToken).ConfigureAwait(false);
-            var configWithFetchResult = await RefreshConfigCoreAsync(latestConfig, cancellationToken).ConfigureAwait(false);
+            var configWithFetchResult = await RefreshConfigCoreAsync(latestConfig, isInitiatedByUser: true, cancellationToken).ConfigureAwait(false);
             return RefreshResult.From(configWithFetchResult.Item2);
         }
         else
@@ -121,7 +121,7 @@ internal abstract class ConfigServiceBase : IDisposable
         }
     }
 
-    protected async Task<ConfigWithFetchResult> RefreshConfigCoreAsync(ProjectConfig latestConfig, CancellationToken cancellationToken)
+    protected async Task<ConfigWithFetchResult> RefreshConfigCoreAsync(ProjectConfig latestConfig, bool isInitiatedByUser, CancellationToken cancellationToken)
     {
         var fetchResult = await this.ConfigFetcher.FetchAsync(latestConfig, cancellationToken).ConfigureAwait(false);
 
@@ -133,23 +133,26 @@ internal abstract class ConfigServiceBase : IDisposable
             latestConfig = fetchResult.Config;
         }
 
-        OnConfigFetched(fetchResult.Config);
+        OnConfigFetched(fetchResult, isInitiatedByUser);
 
         if (fetchResult.IsSuccess)
         {
-            OnConfigChanged(fetchResult.Config);
+            OnConfigChanged(fetchResult);
         }
 
         return new ConfigWithFetchResult(latestConfig, fetchResult);
     }
 
-    protected virtual void OnConfigFetched(ProjectConfig newConfig) { }
+    protected virtual void OnConfigFetched(in FetchResult fetchResult, bool isInitiatedByUser)
+    {
+        this.Hooks.RaiseConfigFetched(RefreshResult.From(fetchResult), isInitiatedByUser);
+    }
 
-    protected virtual void OnConfigChanged(ProjectConfig newConfig)
+    protected virtual void OnConfigChanged(in FetchResult fetchResult)
     {
         this.Logger.Debug("config changed");
 
-        this.Hooks.RaiseConfigChanged(newConfig.Config ?? new Config());
+        this.Hooks.RaiseConfigChanged(fetchResult.Config.Config ?? new Config());
     }
 
     public bool IsOffline

--- a/src/ConfigCatClient/ConfigService/ConfigServiceBase.cs
+++ b/src/ConfigCatClient/ConfigService/ConfigServiceBase.cs
@@ -80,7 +80,7 @@ internal abstract class ConfigServiceBase : IDisposable
         else
         {
             var logMessage = this.Logger.ConfigServiceCannotInitiateHttpCalls();
-            return RefreshResult.Failure(logMessage.InvariantFormattedMessage);
+            return RefreshResult.Failure(RefreshErrorCode.OfflineClient, logMessage.InvariantFormattedMessage);
         }
     }
 
@@ -117,7 +117,7 @@ internal abstract class ConfigServiceBase : IDisposable
         else
         {
             var logMessage = this.Logger.ConfigServiceCannotInitiateHttpCalls();
-            return RefreshResult.Failure(logMessage.InvariantFormattedMessage);
+            return RefreshResult.Failure(RefreshErrorCode.OfflineClient, logMessage.InvariantFormattedMessage);
         }
     }
 

--- a/src/ConfigCatClient/ConfigService/LazyLoadConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/LazyLoadConfigService.cs
@@ -30,7 +30,7 @@ internal sealed class LazyLoadConfigService : ConfigServiceBase, IConfigService
 
             if (!IsOffline)
             {
-                var configWithFetchResult = RefreshConfigCore(cachedConfig);
+                var configWithFetchResult = RefreshConfigCore(cachedConfig, isInitiatedByUser: false);
                 return configWithFetchResult.Item1;
             }
         }
@@ -51,7 +51,7 @@ internal sealed class LazyLoadConfigService : ConfigServiceBase, IConfigService
 
             if (!IsOffline)
             {
-                var configWithFetchResult = await RefreshConfigCoreAsync(cachedConfig, cancellationToken).ConfigureAwait(false);
+                var configWithFetchResult = await RefreshConfigCoreAsync(cachedConfig, isInitiatedByUser: false, cancellationToken).ConfigureAwait(false);
                 return configWithFetchResult.Item1;
             }
         }

--- a/src/ConfigCatClient/ConfigService/NullConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/NullConfigService.cs
@@ -18,7 +18,11 @@ internal sealed class NullConfigService : IConfigService
 
     public ValueTask<ProjectConfig> GetConfigAsync(CancellationToken cancellationToken = default) => new ValueTask<ProjectConfig>(ProjectConfig.Empty);
 
-    public RefreshResult RefreshConfig() { return RefreshResult.Failure($"Client is configured to use the {nameof(OverrideBehaviour.LocalOnly)} override behavior, which prevents making HTTP requests."); }
+    public RefreshResult RefreshConfig()
+    {
+        return RefreshResult.Failure(RefreshErrorCode.LocalOnlyClient,
+            $"Client is configured to use the {nameof(OverrideBehaviour.LocalOnly)} override behavior, which prevents making HTTP requests.");
+    }
 
     public ValueTask<RefreshResult> RefreshConfigAsync(CancellationToken cancellationToken = default) => new ValueTask<RefreshResult>(RefreshConfig());
 

--- a/src/ConfigCatClient/Configuration/ConfigCatClientOptions.cs
+++ b/src/ConfigCatClient/Configuration/ConfigCatClientOptions.cs
@@ -128,6 +128,13 @@ public class ConfigCatClientOptions : IProvidesHooks
     }
 
     /// <inheritdoc/>
+    public event EventHandler<ConfigFetchedEventArgs>? ConfigFetched
+    {
+        add { this.hooks.ConfigFetched += value; }
+        remove { this.hooks.ConfigFetched -= value; }
+    }
+
+    /// <inheritdoc/>
     public event EventHandler<ConfigChangedEventArgs>? ConfigChanged
     {
         add { this.hooks.ConfigChanged += value; }

--- a/src/ConfigCatClient/Evaluation/EvaluationDetails.cs
+++ b/src/ConfigCatClient/Evaluation/EvaluationDetails.cs
@@ -86,6 +86,11 @@ public abstract class EvaluationDetails
     public bool IsDefaultValue { get; set; }
 
     /// <summary>
+    /// The code identifying the reason for the error in case evaluation failed.
+    /// </summary>
+    public EvaluationErrorCode ErrorCode { get; set; }
+
+    /// <summary>
     /// Error message in case evaluation failed.
     /// </summary>
     public string? ErrorMessage { get; set; }
@@ -94,8 +99,6 @@ public abstract class EvaluationDetails
     /// The <see cref="Exception"/> object related to the error in case evaluation failed (if any).
     /// </summary>
     public Exception? ErrorException { get; set; }
-
-    public EvaluationErrorCode ErrorCode { get; set; }
 
     /// <summary>
     /// The targeting rule (if any) that matched during the evaluation and was used to return the evaluated value.

--- a/src/ConfigCatClient/Evaluation/EvaluationDetails.cs
+++ b/src/ConfigCatClient/Evaluation/EvaluationDetails.cs
@@ -28,14 +28,15 @@ public abstract class EvaluationDetails
     }
 
     internal static EvaluationDetails<TValue> FromDefaultValue<TValue>(string key, TValue defaultValue, DateTime? fetchTime, User? user,
-        string? errorMessage = null, Exception? errorException = null)
+        string errorMessage, Exception? errorException = null, EvaluationErrorCode errorCode = EvaluationErrorCode.UnexpectedError)
     {
         var instance = new EvaluationDetails<TValue>(key, defaultValue)
         {
             User = user,
             IsDefaultValue = true,
             ErrorMessage = errorMessage,
-            ErrorException = errorException
+            ErrorException = errorException,
+            ErrorCode = errorCode,
         };
 
         if (fetchTime is not null)
@@ -93,6 +94,8 @@ public abstract class EvaluationDetails
     /// The <see cref="Exception"/> object related to the error in case evaluation failed (if any).
     /// </summary>
     public Exception? ErrorException { get; set; }
+
+    public EvaluationErrorCode ErrorCode { get; set; }
 
     /// <summary>
     /// The targeting rule (if any) that matched during the evaluation and was used to return the evaluated value.

--- a/src/ConfigCatClient/Evaluation/EvaluationErrorCode.cs
+++ b/src/ConfigCatClient/Evaluation/EvaluationErrorCode.cs
@@ -1,11 +1,32 @@
 namespace ConfigCat.Client;
 
+/// <summary>
+/// Specifies the possible evaluation error codes.
+/// </summary>
 public enum EvaluationErrorCode
 {
+    /// <summary>
+    /// An unexpected error occurred during the evaluation.
+    /// </summary>
     UnexpectedError = -1,
+    /// <summary>
+    /// No error occurred (the evaluation was successful).
+    /// </summary>
     None = 0,
+    /// <summary>
+    /// The evaluation failed because of an error in the config model. (Most likely, invalid data was passed to the SDK via flag overrides.)
+    /// </summary>
     InvalidConfigModel = 1,
+    /// <summary>
+    /// The evaluation failed because of a type mismatch between the evaluated setting value and the specified default value.
+    /// </summary>
     SettingValueTypeMismatch = 2,
+    /// <summary>
+    /// The evaluation failed because the config JSON was not available locally.
+    /// </summary>
     ConfigJsonNotAvailable = 1000,
+    /// <summary>
+    /// The evaluation failed because the key of the evaluated setting was not found in the config JSON.
+    /// </summary>
     SettingKeyMissing = 1001,
 }

--- a/src/ConfigCatClient/Evaluation/EvaluationErrorCode.cs
+++ b/src/ConfigCatClient/Evaluation/EvaluationErrorCode.cs
@@ -1,0 +1,11 @@
+namespace ConfigCat.Client;
+
+public enum EvaluationErrorCode
+{
+    UnexpectedError = -1,
+    None = 0,
+    InvalidConfigModel = 1,
+    SettingValueTypeMismatch = 2,
+    ConfigJsonNotAvailable = 1000,
+    SettingKeyMissing = 1001,
+}

--- a/src/ConfigCatClient/Evaluation/EvaluationErrorException.cs
+++ b/src/ConfigCatClient/Evaluation/EvaluationErrorException.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace ConfigCat.Client.Evaluation;
+
+internal sealed class EvaluationErrorException : InvalidOperationException
+{
+    public EvaluationErrorException(EvaluationErrorCode errorCode, string message) : base(message)
+    {
+        ErrorCode = errorCode;
+    }
+
+    public EvaluationErrorCode ErrorCode { get; }
+}

--- a/src/ConfigCatClient/Evaluation/RolloutEvaluatorExtensions.cs
+++ b/src/ConfigCatClient/Evaluation/RolloutEvaluatorExtensions.cs
@@ -15,14 +15,16 @@ internal static class RolloutEvaluatorExtensions
         if (settings is null)
         {
             logMessage = logger.ConfigJsonIsNotPresent(key, nameof(defaultValue), defaultValue);
-            return EvaluationDetails.FromDefaultValue(key, defaultValue, fetchTime: remoteConfig?.TimeStamp, user, logMessage.InvariantFormattedMessage);
+            return EvaluationDetails.FromDefaultValue(key, defaultValue, fetchTime: remoteConfig?.TimeStamp, user,
+                logMessage.InvariantFormattedMessage, errorCode: EvaluationErrorCode.ConfigJsonNotAvailable);
         }
 
         if (!settings.TryGetValue(key, out var setting))
         {
             var availableKeys = new StringListFormatter(settings.Keys).ToString();
             logMessage = logger.SettingEvaluationFailedDueToMissingKey(key, nameof(defaultValue), defaultValue, availableKeys);
-            return EvaluationDetails.FromDefaultValue(key, defaultValue, fetchTime: remoteConfig?.TimeStamp, user, logMessage.InvariantFormattedMessage);
+            return EvaluationDetails.FromDefaultValue(key, defaultValue, fetchTime: remoteConfig?.TimeStamp, user,
+                logMessage.InvariantFormattedMessage, errorCode: EvaluationErrorCode.SettingKeyMissing);
         }
 
         var evaluateContext = new EvaluateContext(key, setting, user, settings);
@@ -65,7 +67,8 @@ internal static class RolloutEvaluatorExtensions
             {
                 exceptionList ??= new List<Exception>();
                 exceptionList.Add(ex);
-                evaluationDetails = EvaluationDetails.FromDefaultValue<object?>(kvp.Key, defaultValue: null, fetchTime: remoteConfig?.TimeStamp, user, ex.Message, ex);
+                evaluationDetails = EvaluationDetails.FromDefaultValue<object?>(kvp.Key, defaultValue: null, fetchTime: remoteConfig?.TimeStamp, user,
+                    ex.Message, ex, GetErrorCode(ex));
             }
 
             evaluationDetailsArray[index++] = evaluationDetails;
@@ -84,5 +87,15 @@ internal static class RolloutEvaluatorExtensions
         }
 
         return true;
+    }
+
+    internal static EvaluationErrorCode GetErrorCode(Exception exception)
+    {
+        return exception switch
+        {
+            EvaluationErrorException evaluationErrorException => evaluationErrorException.ErrorCode,
+            InvalidConfigModelException => EvaluationErrorCode.InvalidConfigModel,
+            _ => EvaluationErrorCode.UnexpectedError,
+        };
     }
 }

--- a/src/ConfigCatClient/FetchResult.cs
+++ b/src/ConfigCatClient/FetchResult.cs
@@ -9,25 +9,26 @@ internal readonly struct FetchResult
 
     public static FetchResult Success(ProjectConfig config)
     {
-        return new FetchResult(config, errorMessageOrToken: null);
+        return new FetchResult(config, RefreshErrorCode.None, errorMessageOrToken: null);
     }
 
     public static FetchResult NotModified(ProjectConfig config)
     {
-        return new FetchResult(config, NotModifiedToken);
+        return new FetchResult(config, RefreshErrorCode.None, NotModifiedToken);
     }
 
-    public static FetchResult Failure(ProjectConfig config, string errorMessage, Exception? errorException = null)
+    public static FetchResult Failure(ProjectConfig config, RefreshErrorCode errorCode, string errorMessage, Exception? errorException = null)
     {
-        return new FetchResult(config, errorMessage, errorException);
+        return new FetchResult(config, errorCode, errorMessage, errorException);
     }
 
     private readonly object? errorMessageOrToken;
 
-    private FetchResult(ProjectConfig config, object? errorMessageOrToken, Exception? errorException = null)
+    private FetchResult(ProjectConfig config, RefreshErrorCode errorCode, object? errorMessageOrToken, Exception? errorException = null)
     {
         Config = config;
         this.errorMessageOrToken = errorMessageOrToken;
+        ErrorCode = errorCode;
         ErrorException = errorException;
     }
 
@@ -37,6 +38,7 @@ internal readonly struct FetchResult
     public bool IsFailure => this.errorMessageOrToken is string;
 
     public ProjectConfig Config { get; }
+    public RefreshErrorCode ErrorCode { get; }
     public string? ErrorMessage => this.errorMessageOrToken as string;
     public Exception? ErrorException { get; }
 }

--- a/src/ConfigCatClient/Hooks/ConfigFetchedEventArgs.cs
+++ b/src/ConfigCatClient/Hooks/ConfigFetchedEventArgs.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace ConfigCat.Client;
+
+/// <summary>
+/// Provides data for the <see cref="ConfigCatClient.ConfigFetched"/> event.
+/// </summary>
+public class ConfigFetchedEventArgs : EventArgs
+{
+    internal ConfigFetchedEventArgs(RefreshResult result, bool isInitiatedByUser)
+    {
+        Result = result;
+        IsInitiatedByUser = isInitiatedByUser;
+    }
+
+    /// <summary>
+    /// The result of the operation.
+    /// </summary>
+    public RefreshResult Result { get; }
+
+    /// <summary>
+    /// Indicates whether the operation was initiated by the user or by the SDK.
+    /// </summary>
+    public bool IsInitiatedByUser { get; }
+}

--- a/src/ConfigCatClient/Hooks/Hooks.cs
+++ b/src/ConfigCatClient/Hooks/Hooks.cs
@@ -5,27 +5,27 @@ namespace ConfigCat.Client;
 
 internal class Hooks : IProvidesHooks
 {
-    private static readonly EventHandlers DisconnectedEventHandlers = new();
+    private static readonly Events DisconnectedEvents = new();
 
-    private volatile EventHandlers eventHandlers;
+    private volatile Events events;
     private IConfigCatClient? client; // should be null only in case of testing
 
-    protected Hooks(EventHandlers eventHandlers)
+    protected Hooks(Events events)
     {
-        this.eventHandlers = eventHandlers;
+        this.events = events;
     }
 
-    public Hooks() : this(new ActualEventHandlers()) { }
+    public Hooks() : this(new RealEvents()) { }
 
     public virtual bool TryDisconnect()
     {
-        // Replacing the current EventHandlers object (eventHandlers) with a special instance of EventHandlers (DisconnectedEventHandlers) achieves multiple things:
+        // Replacing the current Events object (this.events) with a special instance of Events (DisconnectedEvents) achieves multiple things:
         // 1. determines whether the hooks instance has already been disconnected or not,
         // 2. removes implicit references to subscriber objects (so this instance won't keep them alive under any circumstances),
         // 3. makes sure that future subscriptions are ignored from this point on.
-        var originalEventHandlers = Interlocked.Exchange(ref this.eventHandlers, DisconnectedEventHandlers);
+        var originalEvents = Interlocked.Exchange(ref this.events, DisconnectedEvents);
 
-        return !ReferenceEquals(originalEventHandlers, DisconnectedEventHandlers);
+        return !ReferenceEquals(originalEvents, DisconnectedEvents);
     }
 
     public virtual void SetSender(IConfigCatClient client)
@@ -33,69 +33,80 @@ internal class Hooks : IProvidesHooks
         this.client = client;
     }
 
-    /// <inheritdoc/>
+    public void RaiseClientReady()
+        => this.events.RaiseClientReady(this.client);
+
+    public void RaiseFlagEvaluated(EvaluationDetails evaluationDetails)
+        => this.events.RaiseFlagEvaluated(this.client, evaluationDetails);
+
+    public void RaiseConfigChanged(IConfig newConfig)
+        => this.events.RaiseConfigChanged(this.client, newConfig);
+
+    public void RaiseError(string message, Exception? exception)
+        => this.events.RaiseError(this.client, message, exception);
+
     public event EventHandler? ClientReady
     {
-        add { this.eventHandlers.ClientReady += value; }
-        remove { this.eventHandlers.ClientReady -= value; }
+        add { this.events.ClientReady += value; }
+        remove { this.events.ClientReady -= value; }
     }
 
-    internal void RaiseClientReady()
-    {
-        this.eventHandlers.ClientReady?.Invoke(this.client, EventArgs.Empty);
-    }
-
-    /// <inheritdoc/>
     public event EventHandler<FlagEvaluatedEventArgs>? FlagEvaluated
     {
-        add { this.eventHandlers.FlagEvaluated += value; }
-        remove { this.eventHandlers.FlagEvaluated -= value; }
+        add { this.events.FlagEvaluated += value; }
+        remove { this.events.FlagEvaluated -= value; }
     }
 
-    internal void RaiseFlagEvaluated(EvaluationDetails evaluationDetails)
-    {
-        this.eventHandlers.FlagEvaluated?.Invoke(this.client, new FlagEvaluatedEventArgs(evaluationDetails));
-    }
-
-    /// <inheritdoc/>
     public event EventHandler<ConfigChangedEventArgs>? ConfigChanged
     {
-        add { this.eventHandlers.ConfigChanged += value; }
-        remove { this.eventHandlers.ConfigChanged -= value; }
+        add { this.events.ConfigChanged += value; }
+        remove { this.events.ConfigChanged -= value; }
     }
 
-    internal void RaiseConfigChanged(IConfig newConfig)
-    {
-        this.eventHandlers.ConfigChanged?.Invoke(this.client, new ConfigChangedEventArgs(newConfig));
-    }
-
-    /// <inheritdoc/>
     public event EventHandler<ConfigCatClientErrorEventArgs>? Error
     {
-        add { this.eventHandlers.Error += value; }
-        remove { this.eventHandlers.Error -= value; }
+        add { this.events.Error += value; }
+        remove { this.events.Error -= value; }
     }
 
-    internal void RaiseError(string message, Exception? exception)
+    public class Events : IProvidesHooks
     {
-        this.eventHandlers.Error?.Invoke(this.client, new ConfigCatClientErrorEventArgs(message, exception));
+        public virtual void RaiseClientReady(IConfigCatClient? client) { /* intentional no-op */ }
+        public virtual void RaiseFlagEvaluated(IConfigCatClient? client, EvaluationDetails evaluationDetails) { /* intentional no-op */ }
+        public virtual void RaiseConfigChanged(IConfigCatClient? client, IConfig newConfig) { /* intentional no-op */ }
+        public virtual void RaiseError(IConfigCatClient? client, string message, Exception? exception) { /* intentional no-op */ }
+
+        public virtual event EventHandler? ClientReady { add { /* intentional no-op */ } remove { /* intentional no-op */ } }
+        public virtual event EventHandler<FlagEvaluatedEventArgs>? FlagEvaluated { add { /* intentional no-op */ } remove { /* intentional no-op */ } }
+        public virtual event EventHandler<ConfigChangedEventArgs>? ConfigChanged { add { /* intentional no-op */ } remove { /* intentional no-op */ } }
+        public virtual event EventHandler<ConfigCatClientErrorEventArgs>? Error { add { /* intentional no-op */ } remove { /* intentional no-op */ } }
     }
 
-    protected class EventHandlers
+    private sealed class RealEvents : Events
     {
-        private static void Noop(Delegate? _) { /* This method is for keeping SonarQube happy. */ }
+        public override void RaiseClientReady(IConfigCatClient? client)
+        {
+            ClientReady?.Invoke(client, EventArgs.Empty);
+        }
 
-        public virtual EventHandler? ClientReady { get => null; set => Noop(value); }
-        public virtual EventHandler<FlagEvaluatedEventArgs>? FlagEvaluated { get => null; set => Noop(value); }
-        public virtual EventHandler<ConfigChangedEventArgs>? ConfigChanged { get => null; set => Noop(value); }
-        public virtual EventHandler<ConfigCatClientErrorEventArgs>? Error { get => null; set => Noop(value); }
-    }
+        public override void RaiseFlagEvaluated(IConfigCatClient? client, EvaluationDetails evaluationDetails)
+        {
+            FlagEvaluated?.Invoke(client, new FlagEvaluatedEventArgs(evaluationDetails));
+        }
 
-    private sealed class ActualEventHandlers : EventHandlers
-    {
-        public override EventHandler? ClientReady { get; set; }
-        public override EventHandler<FlagEvaluatedEventArgs>? FlagEvaluated { get; set; }
-        public override EventHandler<ConfigChangedEventArgs>? ConfigChanged { get; set; }
-        public override EventHandler<ConfigCatClientErrorEventArgs>? Error { get; set; }
+        public override void RaiseConfigChanged(IConfigCatClient? client, IConfig newConfig)
+        {
+            ConfigChanged?.Invoke(client, new ConfigChangedEventArgs(newConfig));
+        }
+
+        public override void RaiseError(IConfigCatClient? client, string message, Exception? exception)
+        {
+            Error?.Invoke(client, new ConfigCatClientErrorEventArgs(message, exception));
+        }
+
+        public override event EventHandler? ClientReady;
+        public override event EventHandler<FlagEvaluatedEventArgs>? FlagEvaluated;
+        public override event EventHandler<ConfigChangedEventArgs>? ConfigChanged;
+        public override event EventHandler<ConfigCatClientErrorEventArgs>? Error;
     }
 }

--- a/src/ConfigCatClient/Hooks/Hooks.cs
+++ b/src/ConfigCatClient/Hooks/Hooks.cs
@@ -39,6 +39,9 @@ internal class Hooks : IProvidesHooks
     public void RaiseFlagEvaluated(EvaluationDetails evaluationDetails)
         => this.events.RaiseFlagEvaluated(this.client, evaluationDetails);
 
+    public void RaiseConfigFetched(RefreshResult result, bool isInitiatedByUser)
+        => this.events.RaiseConfigFetched(this.client, result, isInitiatedByUser);
+
     public void RaiseConfigChanged(IConfig newConfig)
         => this.events.RaiseConfigChanged(this.client, newConfig);
 
@@ -57,6 +60,12 @@ internal class Hooks : IProvidesHooks
         remove { this.events.FlagEvaluated -= value; }
     }
 
+    public event EventHandler<ConfigFetchedEventArgs>? ConfigFetched
+    {
+        add { this.events.ConfigFetched += value; }
+        remove { this.events.ConfigFetched -= value; }
+    }
+
     public event EventHandler<ConfigChangedEventArgs>? ConfigChanged
     {
         add { this.events.ConfigChanged += value; }
@@ -73,11 +82,13 @@ internal class Hooks : IProvidesHooks
     {
         public virtual void RaiseClientReady(IConfigCatClient? client) { /* intentional no-op */ }
         public virtual void RaiseFlagEvaluated(IConfigCatClient? client, EvaluationDetails evaluationDetails) { /* intentional no-op */ }
+        public virtual void RaiseConfigFetched(IConfigCatClient? client, RefreshResult result, bool isInitiatedByUser) { /* intentional no-op */ }
         public virtual void RaiseConfigChanged(IConfigCatClient? client, IConfig newConfig) { /* intentional no-op */ }
         public virtual void RaiseError(IConfigCatClient? client, string message, Exception? exception) { /* intentional no-op */ }
 
         public virtual event EventHandler? ClientReady { add { /* intentional no-op */ } remove { /* intentional no-op */ } }
         public virtual event EventHandler<FlagEvaluatedEventArgs>? FlagEvaluated { add { /* intentional no-op */ } remove { /* intentional no-op */ } }
+        public virtual event EventHandler<ConfigFetchedEventArgs>? ConfigFetched { add { /* intentional no-op */ } remove { /* intentional no-op */ } }
         public virtual event EventHandler<ConfigChangedEventArgs>? ConfigChanged { add { /* intentional no-op */ } remove { /* intentional no-op */ } }
         public virtual event EventHandler<ConfigCatClientErrorEventArgs>? Error { add { /* intentional no-op */ } remove { /* intentional no-op */ } }
     }
@@ -94,6 +105,11 @@ internal class Hooks : IProvidesHooks
             FlagEvaluated?.Invoke(client, new FlagEvaluatedEventArgs(evaluationDetails));
         }
 
+        public override void RaiseConfigFetched(IConfigCatClient? client, RefreshResult result, bool isInitiatedByUser)
+        {
+            ConfigFetched?.Invoke(client, new ConfigFetchedEventArgs(result, isInitiatedByUser));
+        }
+
         public override void RaiseConfigChanged(IConfigCatClient? client, IConfig newConfig)
         {
             ConfigChanged?.Invoke(client, new ConfigChangedEventArgs(newConfig));
@@ -106,6 +122,7 @@ internal class Hooks : IProvidesHooks
 
         public override event EventHandler? ClientReady;
         public override event EventHandler<FlagEvaluatedEventArgs>? FlagEvaluated;
+        public override event EventHandler<ConfigFetchedEventArgs>? ConfigFetched;
         public override event EventHandler<ConfigChangedEventArgs>? ConfigChanged;
         public override event EventHandler<ConfigCatClientErrorEventArgs>? Error;
     }

--- a/src/ConfigCatClient/Hooks/IProvidesHooks.cs
+++ b/src/ConfigCatClient/Hooks/IProvidesHooks.cs
@@ -18,7 +18,12 @@ public interface IProvidesHooks
     event EventHandler<FlagEvaluatedEventArgs>? FlagEvaluated;
 
     /// <summary>
-    /// Occurs after the locally cached config has been updated.
+    /// Occurs after attempting to refresh the locally cached config by fetching the latest version from the remote server.
+    /// </summary>
+    event EventHandler<ConfigFetchedEventArgs>? ConfigFetched;
+
+    /// <summary>
+    /// Occurs after the locally cached config has been updated to a newer version.
     /// </summary>
     event EventHandler<ConfigChangedEventArgs>? ConfigChanged;
 

--- a/src/ConfigCatClient/Hooks/NullHooks.cs
+++ b/src/ConfigCatClient/Hooks/NullHooks.cs
@@ -4,7 +4,7 @@ internal sealed class NullHooks : Hooks
 {
     public static readonly NullHooks Instance = new();
 
-    private NullHooks() : base(new EventHandlers()) { }
+    private NullHooks() : base(new Events()) { }
 
     public override bool TryDisconnect()
     {

--- a/src/ConfigCatClient/Hooks/SafeHooksWrapper.cs
+++ b/src/ConfigCatClient/Hooks/SafeHooksWrapper.cs
@@ -21,16 +21,24 @@ internal readonly struct SafeHooksWrapper
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public void RaiseClientReady() => Hooks.RaiseClientReady();
+    public void RaiseClientReady()
+        => Hooks.RaiseClientReady();
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public void RaiseFlagEvaluated(EvaluationDetails evaluationDetails) => Hooks.RaiseFlagEvaluated(evaluationDetails);
+    public void RaiseFlagEvaluated(EvaluationDetails evaluationDetails)
+        => Hooks.RaiseFlagEvaluated(evaluationDetails);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public void RaiseConfigChanged(IConfig newConfig) => Hooks.RaiseConfigChanged(newConfig);
+    public void RaiseConfigFetched(RefreshResult result, bool isInitiatedByUser)
+        => Hooks.RaiseConfigFetched(result, isInitiatedByUser);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public void RaiseError(string message, Exception? exception) => Hooks.RaiseError(message, exception);
+    public void RaiseConfigChanged(IConfig newConfig)
+        => Hooks.RaiseConfigChanged(newConfig);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public void RaiseError(string message, Exception? exception)
+        => Hooks.RaiseError(message, exception);
 
     public static implicit operator SafeHooksWrapper(Hooks? hooks) => hooks is not null ? new SafeHooksWrapper(hooks) : default;
 }

--- a/src/ConfigCatClient/Models/ConditionContainer.cs
+++ b/src/ConfigCatClient/Models/ConditionContainer.cs
@@ -49,6 +49,6 @@ internal struct ConditionContainer : IConditionProvider
     public readonly Condition? GetCondition(bool throwIfInvalid = true)
     {
         return this.condition as Condition
-            ?? (!throwIfInvalid ? null : throw new InvalidOperationException("Condition is missing or invalid."));
+            ?? (!throwIfInvalid ? null : throw new InvalidConfigModelException("Condition is missing or invalid."));
     }
 }

--- a/src/ConfigCatClient/Models/InvalidConfigModelException.cs
+++ b/src/ConfigCatClient/Models/InvalidConfigModelException.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace ConfigCat.Client;
+
+internal sealed class InvalidConfigModelException : InvalidOperationException
+{
+    public InvalidConfigModelException(string message) : base(message) { }
+}

--- a/src/ConfigCatClient/Models/PrerequisiteFlagCondition.cs
+++ b/src/ConfigCatClient/Models/PrerequisiteFlagCondition.cs
@@ -43,7 +43,7 @@ internal sealed class PrerequisiteFlagCondition : Condition, IPrerequisiteFlagCo
 #endif
     public string? PrerequisiteFlagKey { get; set; }
 
-    string IPrerequisiteFlagCondition.PrerequisiteFlagKey => PrerequisiteFlagKey ?? throw new InvalidOperationException("Prerequisite flag key is missing.");
+    string IPrerequisiteFlagCondition.PrerequisiteFlagKey => PrerequisiteFlagKey ?? throw new InvalidConfigModelException("Prerequisite flag key is missing.");
 
     private PrerequisiteFlagComparator comparator = UnknownComparator;
 

--- a/src/ConfigCatClient/Models/Segment.cs
+++ b/src/ConfigCatClient/Models/Segment.cs
@@ -38,7 +38,7 @@ internal sealed class Segment : ISegment
 #endif
     public string? Name { get; set; }
 
-    string ISegment.Name => Name ?? throw new InvalidOperationException("Segment name is missing.");
+    string ISegment.Name => Name ?? throw new InvalidConfigModelException("Segment name is missing.");
 
     private UserCondition[]? conditions;
 

--- a/src/ConfigCatClient/Models/SegmentCondition.cs
+++ b/src/ConfigCatClient/Models/SegmentCondition.cs
@@ -40,7 +40,7 @@ internal sealed class SegmentCondition : Condition, ISegmentCondition
     [JsonIgnore]
     public Segment? Segment { get; private set; }
 
-    ISegment ISegmentCondition.Segment => Segment ?? throw new InvalidOperationException("Segment reference is invalid.");
+    ISegment ISegmentCondition.Segment => Segment ?? throw new InvalidConfigModelException("Segment reference is invalid.");
 
     private SegmentComparator comparator = UnknownComparator;
 

--- a/src/ConfigCatClient/Models/SettingValue.cs
+++ b/src/ConfigCatClient/Models/SettingValue.cs
@@ -83,14 +83,14 @@ internal struct SettingValue
             if (HasUnsupportedValue)
             {
                 var unsupportedValue = UnsupportedValue;
-                throw new InvalidOperationException(unsupportedValue is not null
+                throw new InvalidConfigModelException(unsupportedValue is not null
                     ? $"Setting value '{unsupportedValue}' is of an unsupported type ({unsupportedValue.GetType()})."
                     : "Setting value is null.");
             }
             // Value is missing or multiple values specified in the config JSON?
             else
             {
-                throw new InvalidOperationException("Setting value is missing or invalid.");
+                throw new InvalidConfigModelException("Setting value is missing or invalid.");
             }
         }
 
@@ -103,7 +103,7 @@ internal struct SettingValue
 
         if (value is null || value.GetType().ToSettingType() != settingType)
         {
-            return !throwIfInvalid ? null : throw new InvalidOperationException($"Setting value is not of the expected type {settingType}.");
+            return !throwIfInvalid ? null : throw new InvalidConfigModelException($"Setting value is not of the expected type {settingType}.");
         }
 
         return value;

--- a/src/ConfigCatClient/Models/UserCondition.cs
+++ b/src/ConfigCatClient/Models/UserCondition.cs
@@ -45,7 +45,7 @@ internal sealed class UserCondition : Condition, IUserCondition
 #endif
     public string? ComparisonAttribute { get; set; }
 
-    string IUserCondition.ComparisonAttribute => ComparisonAttribute ?? throw new InvalidOperationException("Comparison attribute name is missing.");
+    string IUserCondition.ComparisonAttribute => ComparisonAttribute ?? throw new InvalidConfigModelException("Comparison attribute name is missing.");
 
     private UserComparator comparator = UnknownComparator;
 
@@ -105,7 +105,7 @@ internal sealed class UserCondition : Condition, IUserCondition
     {
         return ModelHelper.IsValidOneOf(this.comparisonValue)
             ? this.comparisonValue
-            : (!throwIfInvalid ? null : throw new InvalidOperationException("Comparison value is missing or invalid."));
+            : (!throwIfInvalid ? null : throw new InvalidConfigModelException("Comparison value is missing or invalid."));
     }
 
     public override string ToString()

--- a/src/ConfigCatClient/RefreshErrorCode.cs
+++ b/src/ConfigCatClient/RefreshErrorCode.cs
@@ -1,0 +1,49 @@
+namespace ConfigCat.Client;
+
+/// <summary>
+/// Specifies the possible config data refresh error codes.
+/// </summary>
+public enum RefreshErrorCode
+{
+    /// <summary>
+    /// An unexpected error occurred during the refresh operation.
+    /// </summary>
+    UnexpectedError = -1,
+    /// <summary>
+    /// No error occurred (the refresh operation was successful).
+    /// </summary>
+    None = 0,
+    /// <summary>
+    /// The refresh operation failed because the client is configured to use the <see cref="OverrideBehaviour.LocalOnly"/> override behavior,
+    /// which prevents making HTTP requests.
+    /// </summary>
+    LocalOnlyClient = 1,
+    /// <summary>
+    /// The refresh operation failed because the client is in offline mode, it cannot initiate HTTP requests.
+    /// </summary>
+    OfflineClient = 3200,
+    /// <summary>
+    /// The refresh operation failed because a HTTP response indicating an invalid SDK Key was received (403 Forbidden or 404 Not Found).
+    /// </summary>
+    InvalidSdkKey = 1100,
+    /// <summary>
+    /// The refresh operation failed because an invalid HTTP response was received (unexpected HTTP status code).
+    /// </summary>
+    UnexpectedHttpResponse = 1101,
+    /// <summary>
+    /// The refresh operation failed because the HTTP request timed out.
+    /// </summary>
+    HttpRequestTimeout = 1102,
+    /// <summary>
+    /// The refresh operation failed because the HTTP request failed (most likely, due to a local network issue).
+    /// </summary>
+    HttpRequestFailure = 1103,
+    /// <summary>
+    /// The refresh operation failed because an invalid HTTP response was received (200 OK with an invalid content).
+    /// </summary>
+    InvalidHttpResponseContent = 1105,
+    /// <summary>
+    /// The refresh operation failed because an invalid HTTP response was received (304 Not Modified when no config JSON was cached locally).
+    /// </summary>
+    InvalidHttpResponseWhenLocalCacheIsEmpty = 1106,
+}

--- a/src/ConfigCatClient/RefreshResult.cs
+++ b/src/ConfigCatClient/RefreshResult.cs
@@ -21,20 +21,24 @@ public readonly struct RefreshResult
     /// Creates an instance of the <see cref="RefreshResult"/> struct which indicates that the operation failed.
     /// </summary>
     /// <returns>The new <see cref="RefreshResult"/> instance.</returns>
-    public static RefreshResult Failure(string errorMessage, Exception? errorException = null)
+    public static RefreshResult Failure(RefreshErrorCode errorCode, string errorMessage, Exception? errorException = null)
     {
-        return new RefreshResult(errorMessage ?? throw new ArgumentNullException(nameof(errorMessage)), errorException);
+        return new RefreshResult(
+            errorCode != RefreshErrorCode.None ? errorCode : throw new ArgumentOutOfRangeException(nameof(errorCode), errorCode, null),
+            errorMessage ?? throw new ArgumentNullException(nameof(errorMessage)),
+            errorException);
     }
 
-    internal static RefreshResult From(FetchResult fetchResult)
+    internal static RefreshResult From(in FetchResult fetchResult)
     {
         return !fetchResult.IsFailure
             ? Success()
-            : Failure(fetchResult.ErrorMessage, fetchResult.ErrorException);
+            : Failure(fetchResult.ErrorCode, fetchResult.ErrorMessage, fetchResult.ErrorException);
     }
 
-    private RefreshResult(string? errorMessage, Exception? errorException)
+    private RefreshResult(RefreshErrorCode errorCode, string? errorMessage, Exception? errorException)
     {
+        ErrorCode = errorCode;
         ErrorMessage = errorMessage;
         ErrorException = errorException;
     }
@@ -44,6 +48,11 @@ public readonly struct RefreshResult
     /// </summary>
     [MemberNotNullWhen(false, nameof(ErrorMessage))]
     public bool IsSuccess => ErrorMessage is null;
+
+    /// <summary>
+    /// The code identifying the reason for the error in case the operation failed.
+    /// </summary>
+    public RefreshErrorCode ErrorCode { get; }
 
     /// <summary>
     /// Error message in case the operation failed, otherwise <see langword="null" />.


### PR DESCRIPTION
### Describe the purpose of your pull request

Define error codes (`EvaluationErrorCode`, `RefreshErrorCode`) and expose them to the user (`EvaluationDetails.ErrorCode`, `RefreshResult.ErrorCode`) so they can reliably identify the error type without resorting to guess it by checking the error message (see also: https://github.com/open-feature/dotnet-sdk-contrib/pull/119#discussion_r1433928330)

The PR also proposes a new hook named `ConfigFetched` which could be used to observe config fetching-related errors even when refreshing is done by the SDK.

### Related issues (only if applicable)

https://trello.com/c/0KrZmHgQ

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
