### PR TITLE
Bugfix to support Dotnet Blazor WASM

### DIFF
--- a/src/ConfigCatClient/HttpConfigFetcher.cs
+++ b/src/ConfigCatClient/HttpConfigFetcher.cs
@@ -249,10 +249,12 @@ internal sealed class HttpConfigFetcher : IConfigFetcher, IDisposable
 
         if (this.httpClientHandler is null)
         {
-            client = new HttpClient(new HttpClientHandler
+            var handler = new HttpClientHandler();
+            if (handler.SupportsAutomaticDecompression)
             {
-                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
-            });
+                handler.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
+            }
+            client = new HttpClient(handler);
         }
         else
         {


### PR DESCRIPTION
### Bugfix to support Dotnet Blazor WASM

- Blazor client doesn't support AutomaticDecompression, but I think this is just a performance optimization so can do without it for now (otherwise configcat cannot be used with blazor client at all)

### Requirement checklist

- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
