### PR TITLE
#92 Change IConfigCatClient.Snapshot() to return IConfigCatClientSnapshot

### DIFF
--- a/src/ConfigCat.Client.Tests/VariationIdTests.cs
+++ b/src/ConfigCat.Client.Tests/VariationIdTests.cs
@@ -58,7 +58,7 @@ public class VariationIdTests
     {
         using var client = CreateClient(isAsync, TestJson);
 
-        ConfigCatClientSnapshot snapshot;
+        IConfigCatClientSnapshot snapshot;
         EvaluationDetails[] allValueDetails =
             isAsync is null ? (snapshot = client.Snapshot()).GetAllKeys().Select(keys => snapshot.GetValueDetails<object?>(keys, null)).ToArray() :
             !isAsync.Value ? client.GetAllValueDetails().ToArray() :
@@ -80,7 +80,7 @@ public class VariationIdTests
     {
         using var client = CreateClient(isAsync, "{}");
 
-        ConfigCatClientSnapshot snapshot;
+        IConfigCatClientSnapshot snapshot;
         EvaluationDetails[] allValueDetails =
             isAsync is null ? (snapshot = client.Snapshot()).GetAllKeys().Select(keys => snapshot.GetValueDetails<object?>(keys, null)).ToArray() :
             !isAsync.Value ? client.GetAllValueDetails().ToArray() :

--- a/src/ConfigCatClient/ConfigCatClient.cs
+++ b/src/ConfigCatClient/ConfigCatClient.cs
@@ -791,7 +791,7 @@ public sealed class ConfigCatClient : IConfigCatClient
     }
 
     /// <inheritdoc />
-    public ConfigCatClientSnapshot Snapshot()
+    public IConfigCatClientSnapshot Snapshot()
     {
         var settings = GetSettings(syncWithExternalCache: false);
         var cacheState = this.configService.GetCacheState(settings.RemoteConfig ?? ProjectConfig.Empty);

--- a/src/ConfigCatClient/IConfigCatClient.cs
+++ b/src/ConfigCatClient/IConfigCatClient.cs
@@ -267,7 +267,7 @@ public interface IConfigCatClient : IProvidesHooks, IDisposable
     /// For other polling modes, you'll need to manually initiate a cache refresh by invoking <see cref="ForceRefresh"/> or <see cref="ForceRefreshAsync"/>.
     /// </remarks>
     /// <returns>The snapshot object.</returns>
-    ConfigCatClientSnapshot Snapshot();
+    IConfigCatClientSnapshot Snapshot();
 
     /// <summary>
     /// Sets the default user.


### PR DESCRIPTION
### Describe the purpose of your pull request

change the return type for IConfigCatClient.Snapshot() from `ConfigCatClientSnapshot` to `IConfigCatClientSnapshot`

### Related issues (only if applicable)

#92 Change IConfigCatClient.Snapshot() to return IConfigCatClientSnapshot

### Requirement checklist (only if applicable)

- [X] I have covered the applied changes with automated tests.
- [X] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [X] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
