### PR TITLE
Custom log filtering

### DIFF
--- a/src/ConfigCat.Client.Tests/ConfigCat.Client.Tests.csproj
+++ b/src/ConfigCat.Client.Tests/ConfigCat.Client.Tests.csproj
@@ -8,7 +8,7 @@
     <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
-    <NoWarn>CS0618</NoWarn>
+    <NoWarn>CS0618;CS1685</NoWarn>
     <AssemblyOriginatorKeyFile>..\ConfigCatClient.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 

--- a/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
+++ b/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
@@ -2114,7 +2114,7 @@ public class ConfigCatClientTests
         var onFetch = (ProjectConfig latestConfig, CancellationToken _) =>
         {
             var logMessage = loggerWrapper.FetchFailedDueToUnexpectedError(errorException);
-            return FetchResult.Failure(latestConfig, RefreshErrorCode.HttpRequestFailure, errorMessage: logMessage.InvariantFormattedMessage, errorException: errorException);
+            return FetchResult.Failure(latestConfig, RefreshErrorCode.HttpRequestFailure, errorMessage: logMessage.ToLazyString(), errorException: errorException);
         };
         this.fetcherMock.Setup(m => m.FetchAsync(It.IsAny<ProjectConfig>(), It.IsAny<CancellationToken>())).ReturnsAsync(onFetch);
 

--- a/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
+++ b/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
@@ -2107,7 +2107,7 @@ public class ConfigCatClientTests
         hooks.FlagEvaluated += (s, e) => flagEvaluatedEvents.Add(e);
         hooks.Error += (s, e) => errorEvents.Add(e);
 
-        var loggerWrapper = this.loggerMock.Object.AsWrapper(hooks);
+        var loggerWrapper = this.loggerMock.Object.AsWrapper(hooks: hooks);
 
         var errorException = new HttpRequestException();
 
@@ -2306,6 +2306,30 @@ public class ConfigCatClientTests
         Assert.AreEqual(2, errorEvents.Count);
     }
 
+    [TestMethod]
+    public async Task LogFilter_Works()
+    {
+        var logEvents = new List<LogEvent>();
+        var logger = LoggingHelper.CreateCapturingLogger(logEvents, LogLevel.Info);
+
+        var options = new ConfigCatClientOptions
+        {
+            Logger = logger,
+            LogFilter = (LogLevel level, LogEventId eventId, ref FormattableLogMessage message, Exception? exception) => eventId != 3001,
+            FlagOverrides = FlagOverrides.LocalFile(Path.Combine("data", "sample_variationid_v5.json"), autoReload: false, OverrideBehaviour.LocalOnly)
+        };
+
+        using var client = new ConfigCatClient("localonly", options);
+
+        var actualValue = await client.GetValueAsync("boolean", (bool?)null);
+        Assert.IsFalse(actualValue);
+
+        Assert.AreEqual(1, logEvents.Count);
+        Assert.AreEqual(LogLevel.Info, logEvents[0].Level);
+        Assert.AreEqual(5000, logEvents[0].EventId);
+        Assert.IsNull(logEvents[0].Exception);
+    }
+
     private static IConfigCatClient CreateClientWithMockedFetcher(string cacheKey,
         Mock<IConfigCatLogger> loggerMock,
         Mock<IConfigFetcher> fetcherMock,
@@ -2375,7 +2399,7 @@ public class ConfigCatClientTests
         var overrideDataSource = overrideDataSourceFactory?.Invoke(loggerWrapper);
 
         configService = configServiceFactory(fetcherMock.Object, cacheParams, loggerWrapper, hooks);
-        return new ConfigCatClient(configService, loggerMock.Object, evaluator, overrideDataSource?.Item1, overrideDataSource?.Item2, hooks);
+        return new ConfigCatClient(configService, loggerMock.Object, evaluator, overrideDataSource?.Item1, overrideDataSource?.Item2, hooks: hooks);
     }
 
     private static int ParseETagAsInt32(string? etag)

--- a/src/ConfigCat.Client.Tests/Helpers/LoggingHelper.cs
+++ b/src/ConfigCat.Client.Tests/Helpers/LoggingHelper.cs
@@ -19,9 +19,9 @@ internal struct LogEvent
 
 internal static class LoggingHelper
 {
-    public static LoggerWrapper AsWrapper(this IConfigCatLogger logger, Hooks? hooks = null)
+    public static LoggerWrapper AsWrapper(this IConfigCatLogger logger, LogFilterCallback? filter = null, Hooks? hooks = null)
     {
-        return new LoggerWrapper(logger, hooks);
+        return new LoggerWrapper(logger, filter, hooks);
     }
 
     public static IConfigCatLogger CreateCapturingLogger(List<LogEvent> logEvents, LogLevel logLevel = LogLevel.Info)

--- a/src/ConfigCat.Client.Tests/UtilsTests.cs
+++ b/src/ConfigCat.Client.Tests/UtilsTests.cs
@@ -157,4 +157,26 @@ public class UtilsTests
             Assert.ThrowsException<ArgumentOutOfRangeException>(() => ModelHelper.SetEnum(ref field, enumValue));
         }
     }
+
+    [DataTestMethod]
+    [DataRow(null, false, true, null)]
+    [DataRow("abc", false, true, "abc")]
+    [DataRow("abc", null, false, "abc")]
+    [DataRow("abc", new object?[0], false, "abc")]
+    [DataRow("abc{0}{1}{2}", new object?[] { 0.1, null, 23 }, false, "abc0.123")]
+    public void LazyString_Value_Works(string? valueOrFormat, object args, bool expectedIsValueCreated, string expectedValue)
+    {
+        var lazyString = args is false ? new LazyString(valueOrFormat) : new LazyString(valueOrFormat!, (object?[]?)args);
+
+        Assert.AreEqual(expectedIsValueCreated, lazyString.IsValueCreated);
+
+        var value = lazyString.Value;
+        Assert.AreEqual(expectedValue, value);
+
+        Assert.IsTrue(lazyString.IsValueCreated);
+
+        Assert.AreSame(value, lazyString.Value);
+
+        Assert.AreSame(expectedValue is not null ? value : string.Empty, lazyString.ToString());
+    }
 }

--- a/src/ConfigCat.Client.Tests/UtilsTests.cs
+++ b/src/ConfigCat.Client.Tests/UtilsTests.cs
@@ -164,7 +164,7 @@ public class UtilsTests
     [DataRow("abc", null, false, "abc")]
     [DataRow("abc", new object?[0], false, "abc")]
     [DataRow("abc{0}{1}{2}", new object?[] { 0.1, null, 23 }, false, "abc0.123")]
-    public void LazyString_Value_Works(string? valueOrFormat, object args, bool expectedIsValueCreated, string expectedValue)
+    public void LazyString_Value_Works(string? valueOrFormat, object? args, bool expectedIsValueCreated, string? expectedValue)
     {
         var lazyString = args is false ? new LazyString(valueOrFormat) : new LazyString(valueOrFormat!, (object?[]?)args);
 

--- a/src/ConfigCatClient/ConfigCatClient.cs
+++ b/src/ConfigCatClient/ConfigCatClient.cs
@@ -85,7 +85,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         // hold a strong reference to the hooks object (see also SafeHooksWrapper).
         var hooksWrapper = new SafeHooksWrapper(this.hooks);
 
-        var logger = new LoggerWrapper(options.Logger ?? ConfigCatClientOptions.CreateDefaultLogger(), hooksWrapper);
+        var logger = new LoggerWrapper(options.Logger ?? ConfigCatClientOptions.CreateDefaultLogger(), options.LogFilter, hooksWrapper);
         var evaluator = new RolloutEvaluator(logger);
 
         this.evaluationServices = new EvaluationServices(evaluator, hooksWrapper, logger);
@@ -125,13 +125,14 @@ public sealed class ConfigCatClient : IConfigCatClient
 
     // For test purposes only
     internal ConfigCatClient(IConfigService configService, IConfigCatLogger logger, IRolloutEvaluator evaluator,
-        OverrideBehaviour? overrideBehaviour = null, IOverrideDataSource? overrideDataSource = null, Hooks? hooks = null)
+        OverrideBehaviour? overrideBehaviour = null, IOverrideDataSource? overrideDataSource = null,
+        LogFilterCallback? logFilter = null, Hooks? hooks = null)
     {
         this.hooks = hooks ?? NullHooks.Instance;
         this.hooks.SetSender(this);
         var hooksWrapper = new SafeHooksWrapper(this.hooks);
 
-        this.evaluationServices = new EvaluationServices(evaluator, hooksWrapper, new LoggerWrapper(logger, hooks));
+        this.evaluationServices = new EvaluationServices(evaluator, hooksWrapper, new LoggerWrapper(logger, logFilter, hooks));
 
         this.configService = configService;
 

--- a/src/ConfigCatClient/ConfigService/ConfigServiceBase.cs
+++ b/src/ConfigCatClient/ConfigService/ConfigServiceBase.cs
@@ -96,7 +96,7 @@ internal abstract class ConfigServiceBase : IDisposable
         else
         {
             var logMessage = this.Logger.ConfigServiceCannotInitiateHttpCalls();
-            return RefreshResult.Failure(RefreshErrorCode.OfflineClient, logMessage.InvariantFormattedMessage);
+            return RefreshResult.Failure(RefreshErrorCode.OfflineClient, logMessage.ToLazyString());
         }
     }
 
@@ -133,7 +133,7 @@ internal abstract class ConfigServiceBase : IDisposable
         else
         {
             var logMessage = this.Logger.ConfigServiceCannotInitiateHttpCalls();
-            return RefreshResult.Failure(RefreshErrorCode.OfflineClient, logMessage.InvariantFormattedMessage);
+            return RefreshResult.Failure(RefreshErrorCode.OfflineClient, logMessage.ToLazyString());
         }
     }
 

--- a/src/ConfigCatClient/Configuration/ConfigCatClientOptions.cs
+++ b/src/ConfigCatClient/Configuration/ConfigCatClientOptions.cs
@@ -18,6 +18,12 @@ public class ConfigCatClientOptions : IProvidesHooks
     private Hooks hooks = new();
 
     /// <summary>
+    /// An optional callback that can be used to filter log events beyond the minimum log level setting
+    /// (<see cref="IConfigCatLogger.LogLevel"/> and <see cref="ConfigCatClient.LogLevel"/>).
+    /// </summary>
+    public LogFilterCallback? LogFilter { get; set; }
+
+    /// <summary>
     /// The logger implementation to use for performing logging.
     /// If not set, <see cref="ConsoleLogger"/> with <see cref="LogLevel.Warning"/> will be used by default.<br/>
     /// If you want to use custom logging instead, you can provide an implementation of <see cref="IConfigCatLogger"/>.

--- a/src/ConfigCatClient/Evaluation/EvaluationDetails.cs
+++ b/src/ConfigCatClient/Evaluation/EvaluationDetails.cs
@@ -1,5 +1,6 @@
 using System;
 using ConfigCat.Client.Evaluation;
+using ConfigCat.Client.Utils;
 
 namespace ConfigCat.Client;
 
@@ -28,13 +29,13 @@ public abstract class EvaluationDetails
     }
 
     internal static EvaluationDetails<TValue> FromDefaultValue<TValue>(string key, TValue defaultValue, DateTime? fetchTime, User? user,
-        string errorMessage, Exception? errorException = null, EvaluationErrorCode errorCode = EvaluationErrorCode.UnexpectedError)
+        LazyString errorMessage, Exception? errorException = null, EvaluationErrorCode errorCode = EvaluationErrorCode.UnexpectedError)
     {
         var instance = new EvaluationDetails<TValue>(key, defaultValue)
         {
             User = user,
             IsDefaultValue = true,
-            ErrorMessage = errorMessage,
+            errorMessage = errorMessage,
             ErrorException = errorException,
             ErrorCode = errorCode,
         };
@@ -46,6 +47,8 @@ public abstract class EvaluationDetails
 
         return instance;
     }
+
+    private LazyString errorMessage;
 
     private protected EvaluationDetails(string key)
     {
@@ -93,7 +96,11 @@ public abstract class EvaluationDetails
     /// <summary>
     /// Error message in case evaluation failed.
     /// </summary>
-    public string? ErrorMessage { get; set; }
+    public string? ErrorMessage
+    {
+        get => this.errorMessage.ToString();
+        set => this.errorMessage = value;
+    }
 
     /// <summary>
     /// The <see cref="Exception"/> object related to the error in case evaluation failed (if any).

--- a/src/ConfigCatClient/Evaluation/EvaluationDetails.cs
+++ b/src/ConfigCatClient/Evaluation/EvaluationDetails.cs
@@ -98,7 +98,7 @@ public abstract class EvaluationDetails
     /// </summary>
     public string? ErrorMessage
     {
-        get => this.errorMessage.ToString();
+        get => this.errorMessage.Value;
         set => this.errorMessage = value;
     }
 

--- a/src/ConfigCatClient/Evaluation/EvaluationHelper.cs
+++ b/src/ConfigCatClient/Evaluation/EvaluationHelper.cs
@@ -17,15 +17,15 @@ internal static class EvaluationHelper
         {
             logMessage = logger.ConfigJsonIsNotPresent(key, nameof(defaultValue), defaultValue);
             return EvaluationDetails.FromDefaultValue(key, defaultValue, fetchTime: remoteConfig?.TimeStamp, user,
-                logMessage.InvariantFormattedMessage, errorCode: EvaluationErrorCode.ConfigJsonNotAvailable);
+                logMessage.ToLazyString(), errorCode: EvaluationErrorCode.ConfigJsonNotAvailable);
         }
 
         if (!settings.TryGetValue(key, out var setting))
         {
-            var availableKeys = new StringListFormatter(settings.Keys).ToString();
+            var availableKeys = new StringListFormatter(settings.Keys);
             logMessage = logger.SettingEvaluationFailedDueToMissingKey(key, nameof(defaultValue), defaultValue, availableKeys);
             return EvaluationDetails.FromDefaultValue(key, defaultValue, fetchTime: remoteConfig?.TimeStamp, user,
-                logMessage.InvariantFormattedMessage, errorCode: EvaluationErrorCode.SettingKeyMissing);
+                logMessage.ToLazyString(), errorCode: EvaluationErrorCode.SettingKeyMissing);
         }
 
         var evaluateContext = new EvaluateContext(key, setting, user, settings);

--- a/src/ConfigCatClient/FetchResult.cs
+++ b/src/ConfigCatClient/FetchResult.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
+using ConfigCat.Client.Utils;
 
 namespace ConfigCat.Client;
 
@@ -17,12 +18,12 @@ internal readonly struct FetchResult
         return new FetchResult(config, RefreshErrorCode.None, NotModifiedToken);
     }
 
-    public static FetchResult Failure(ProjectConfig config, RefreshErrorCode errorCode, string errorMessage, Exception? errorException = null)
+    public static FetchResult Failure(ProjectConfig config, RefreshErrorCode errorCode, LazyString errorMessage, Exception? errorException = null)
     {
-        return new FetchResult(config, errorCode, errorMessage, errorException);
+        return new FetchResult(config, errorCode, errorMessage.Value ?? (object)errorMessage, errorException);
     }
 
-    private readonly object? errorMessageOrToken;
+    private readonly object? errorMessageOrToken; // either null or a string or a boxed LazyString or NotModifiedToken
 
     private FetchResult(ProjectConfig config, RefreshErrorCode errorCode, object? errorMessageOrToken, Exception? errorException = null)
     {
@@ -35,10 +36,10 @@ internal readonly struct FetchResult
     public bool IsSuccess => this.errorMessageOrToken is null;
     public bool IsNotModified => ReferenceEquals(this.errorMessageOrToken, NotModifiedToken);
     [MemberNotNullWhen(true, nameof(ErrorMessage))]
-    public bool IsFailure => this.errorMessageOrToken is string;
+    public bool IsFailure => !IsSuccess && !IsNotModified;
 
     public ProjectConfig Config { get; }
     public RefreshErrorCode ErrorCode { get; }
-    public string? ErrorMessage => this.errorMessageOrToken as string;
+    public object? ErrorMessage => !IsNotModified ? this.errorMessageOrToken : null;
     public Exception? ErrorException { get; }
 }

--- a/src/ConfigCatClient/FetchResult.cs
+++ b/src/ConfigCatClient/FetchResult.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using ConfigCat.Client.Utils;
 
@@ -20,7 +22,8 @@ internal readonly struct FetchResult
 
     public static FetchResult Failure(ProjectConfig config, RefreshErrorCode errorCode, LazyString errorMessage, Exception? errorException = null)
     {
-        return new FetchResult(config, errorCode, errorMessage.Value ?? (object)errorMessage, errorException);
+        Debug.Assert(!EqualityComparer<LazyString>.Default.Equals(errorMessage, default));
+        return new FetchResult(config, errorCode, errorMessage.IsValueCreated ? errorMessage.Value : (object)errorMessage, errorException);
     }
 
     private readonly object? errorMessageOrToken; // either null or a string or a boxed LazyString or NotModifiedToken

--- a/src/ConfigCatClient/FormattableString.cs
+++ b/src/ConfigCatClient/FormattableString.cs
@@ -1,51 +1,18 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// Source: https://github.com/dotnet/runtime/blob/v6.0.13/src/libraries/System.Private.CoreLib/src/System/FormattableString.cs
-
-#if NET45
+// Based on: https://github.com/dotnet/runtime/blob/v6.0.13/src/libraries/System.Private.CoreLib/src/System/FormattableString.cs
+// This is a modified version of the built-in type that is used only internally in the SDK.
 
 #pragma warning disable IDE0161 // Convert to file-scoped namespace
+#pragma warning disable CS0436 // Type conflicts with imported type
+
+global using ValueFormattableString = System.FormattableString;
 
 namespace System
 {
-    /// <summary>
-    /// A composite format string along with the arguments to be formatted. An instance of this
-    /// type may result from the use of the C# or VB language primitive "interpolated string".
-    /// </summary>
-    internal abstract class FormattableString : IFormattable
+    internal readonly struct FormattableString : IFormattable
     {
-        /// <summary>
-        /// The composite format string.
-        /// </summary>
-        public abstract string Format { get; }
-
-        /// <summary>
-        /// Returns an object array that contains zero or more objects to format. Clients should not
-        /// mutate the contents of the array.
-        /// </summary>
-        public abstract object?[] GetArguments();
-
-        /// <summary>
-        /// The number of arguments to be formatted.
-        /// </summary>
-        public abstract int ArgumentCount { get; }
-
-        /// <summary>
-        /// Returns one argument to be formatted from argument position <paramref name="index"/>.
-        /// </summary>
-        public abstract object? GetArgument(int index);
-
-        /// <summary>
-        /// Format to a string using the given culture.
-        /// </summary>
-        public abstract string ToString(IFormatProvider? formatProvider);
-
-        string IFormattable.ToString(string? ignored, IFormatProvider? formatProvider)
-        {
-            return ToString(formatProvider);
-        }
-
         /// <summary>
         /// Format the given object in the invariant culture. This static method may be
         /// imported in C# by
@@ -61,11 +28,6 @@ namespace System
         /// </summary>
         public static string Invariant(FormattableString formattable)
         {
-            if (formattable == null)
-            {
-                throw new ArgumentNullException(nameof(formattable));
-            }
-
             return formattable.ToString(Globalization.CultureInfo.InvariantCulture);
         }
 
@@ -84,19 +46,25 @@ namespace System
         /// </summary>
         public static string CurrentCulture(FormattableString formattable)
         {
-            if (formattable == null)
-            {
-                throw new ArgumentNullException(nameof(formattable));
-            }
-
             return formattable.ToString(Globalization.CultureInfo.CurrentCulture);
         }
 
-        public override string ToString()
+        private readonly string format;
+        private readonly object?[] arguments;
+
+        internal FormattableString(string format, object?[] arguments)
         {
-            return ToString(Globalization.CultureInfo.CurrentCulture);
+            this.format = format;
+            this.arguments = arguments;
         }
+
+        public string Format => this.format ?? string.Empty;
+        public object?[] GetArguments() { return this.arguments; }
+        public int ArgumentCount => this.arguments?.Length ?? 0;
+        public object? GetArgument(int index) { return this.arguments[index]; }
+
+        public string ToString(string? format, IFormatProvider? formatProvider) { return ToString(formatProvider); }
+        public string ToString(IFormatProvider? formatProvider) { return string.Format(formatProvider, this.format, this.arguments); }
+        public override string ToString() { return ToString(Globalization.CultureInfo.CurrentCulture); }
     }
 }
-
-#endif

--- a/src/ConfigCatClient/FormattableString.cs
+++ b/src/ConfigCatClient/FormattableString.cs
@@ -13,42 +13,6 @@ namespace System
 {
     internal readonly struct FormattableString : IFormattable
     {
-        /// <summary>
-        /// Format the given object in the invariant culture. This static method may be
-        /// imported in C# by
-        /// <code>
-        /// using static System.FormattableString;
-        /// </code>.
-        /// Within the scope
-        /// of that import directive an interpolated string may be formatted in the
-        /// invariant culture by writing, for example,
-        /// <code>
-        /// Invariant($"{{ lat = {latitude}; lon = {longitude} }}")
-        /// </code>
-        /// </summary>
-        public static string Invariant(FormattableString formattable)
-        {
-            return formattable.ToString(Globalization.CultureInfo.InvariantCulture);
-        }
-
-        /// <summary>
-        /// Format the given object in the current culture. This static method may be
-        /// imported in C# by
-        /// <code>
-        /// using static System.FormattableString;
-        /// </code>.
-        /// Within the scope
-        /// of that import directive an interpolated string may be formatted in the
-        /// current culture by writing, for example,
-        /// <code>
-        /// CurrentCulture($"{{ lat = {latitude}; lon = {longitude} }}")
-        /// </code>
-        /// </summary>
-        public static string CurrentCulture(FormattableString formattable)
-        {
-            return formattable.ToString(Globalization.CultureInfo.CurrentCulture);
-        }
-
         private readonly string format;
         private readonly object?[] arguments;
 
@@ -60,11 +24,9 @@ namespace System
 
         public string Format => this.format ?? string.Empty;
         public object?[] GetArguments() { return this.arguments; }
-        public int ArgumentCount => this.arguments?.Length ?? 0;
-        public object? GetArgument(int index) { return this.arguments[index]; }
 
         public string ToString(string? format, IFormatProvider? formatProvider) { return ToString(formatProvider); }
-        public string ToString(IFormatProvider? formatProvider) { return string.Format(formatProvider, this.format, this.arguments); }
+        public string ToString(IFormatProvider? formatProvider) { return string.Format(formatProvider, Format, this.arguments); }
         public override string ToString() { return ToString(Globalization.CultureInfo.CurrentCulture); }
     }
 }

--- a/src/ConfigCatClient/FormattableStringFactory.cs
+++ b/src/ConfigCatClient/FormattableStringFactory.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Based on: https://github.com/dotnet/runtime/blob/v6.0.13/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/FormattableStringFactory.cs
-// This is a modified version of the built-in type that is only used only internally in the SDK. It allows
-// creating value type instances instead of reference type instances to avoid unnecessary heap allocations.
+// This is a modified version of the built-in type that is only used only internally in the SDK.
+// It creates value type instances instead of reference type instances to avoid unnecessary heap allocations.
 
 #pragma warning disable IDE0161 // Convert to file-scoped namespace
 #pragma warning disable CS0436 // Type conflicts with imported type
@@ -19,7 +19,7 @@ namespace System.Runtime.CompilerServices
         /// Create a <see cref="FormattableString"/> from a composite format string and object
         /// array containing zero or more objects to format.
         /// </summary>
-        public static FormattableString Create(string format, params object?[] arguments)
+        public static ValueFormattableString Create(string format, params object?[] arguments)
         {
             if (format == null)
             {
@@ -31,7 +31,7 @@ namespace System.Runtime.CompilerServices
                 throw new ArgumentNullException(nameof(arguments));
             }
 
-            return new FormattableString(format, arguments);
+            return new ValueFormattableString(format, arguments);
         }
     }
 }

--- a/src/ConfigCatClient/FormattableStringFactory.cs
+++ b/src/ConfigCatClient/FormattableStringFactory.cs
@@ -1,13 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// Source: https://github.com/dotnet/runtime/blob/v6.0.13/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/FormattableStringFactory.cs
-
-#if NET45
+// Based on: https://github.com/dotnet/runtime/blob/v6.0.13/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/FormattableStringFactory.cs
+// This is a modified version of the built-in type that is only used only internally in the SDK. It allows
+// creating value type instances instead of reference type instances to avoid unnecessary heap allocations.
 
 #pragma warning disable IDE0161 // Convert to file-scoped namespace
-#pragma warning disable IDE1006 // Naming Styles
-#pragma warning disable IDE0009 // Member access should be qualified.
+#pragma warning disable CS0436 // Type conflicts with imported type
 
 namespace System.Runtime.CompilerServices
 {
@@ -32,27 +31,7 @@ namespace System.Runtime.CompilerServices
                 throw new ArgumentNullException(nameof(arguments));
             }
 
-            return new ConcreteFormattableString(format, arguments);
-        }
-
-        private sealed class ConcreteFormattableString : FormattableString
-        {
-            private readonly string _format;
-            private readonly object?[] _arguments;
-
-            internal ConcreteFormattableString(string format, object?[] arguments)
-            {
-                _format = format;
-                _arguments = arguments;
-            }
-
-            public override string Format => _format;
-            public override object?[] GetArguments() { return _arguments; }
-            public override int ArgumentCount => _arguments.Length;
-            public override object? GetArgument(int index) { return _arguments[index]; }
-            public override string ToString(IFormatProvider? formatProvider) { return string.Format(formatProvider, _format, _arguments); }
+            return new FormattableString(format, arguments);
         }
     }
 }
-
-#endif

--- a/src/ConfigCatClient/Hooks/Hooks.cs
+++ b/src/ConfigCatClient/Hooks/Hooks.cs
@@ -45,8 +45,8 @@ internal class Hooks : IProvidesHooks
     public void RaiseConfigChanged(IConfig newConfig)
         => this.events.RaiseConfigChanged(this.client, newConfig);
 
-    public void RaiseError(string message, Exception? exception)
-        => this.events.RaiseError(this.client, message, exception);
+    public void RaiseError(ref FormattableLogMessage message, Exception? exception)
+        => this.events.RaiseError(this.client, ref message, exception);
 
     public event EventHandler<ClientReadyEventArgs>? ClientReady
     {
@@ -84,7 +84,7 @@ internal class Hooks : IProvidesHooks
         public virtual void RaiseFlagEvaluated(IConfigCatClient? client, EvaluationDetails evaluationDetails) { /* intentional no-op */ }
         public virtual void RaiseConfigFetched(IConfigCatClient? client, RefreshResult result, bool isInitiatedByUser) { /* intentional no-op */ }
         public virtual void RaiseConfigChanged(IConfigCatClient? client, IConfig newConfig) { /* intentional no-op */ }
-        public virtual void RaiseError(IConfigCatClient? client, string message, Exception? exception) { /* intentional no-op */ }
+        public virtual void RaiseError(IConfigCatClient? client, ref FormattableLogMessage message, Exception? exception) { /* intentional no-op */ }
 
         public virtual event EventHandler<ClientReadyEventArgs>? ClientReady { add { /* intentional no-op */ } remove { /* intentional no-op */ } }
         public virtual event EventHandler<FlagEvaluatedEventArgs>? FlagEvaluated { add { /* intentional no-op */ } remove { /* intentional no-op */ } }
@@ -115,9 +115,9 @@ internal class Hooks : IProvidesHooks
             ConfigChanged?.Invoke(client, new ConfigChangedEventArgs(newConfig));
         }
 
-        public override void RaiseError(IConfigCatClient? client, string message, Exception? exception)
+        public override void RaiseError(IConfigCatClient? client, ref FormattableLogMessage message, Exception? exception)
         {
-            Error?.Invoke(client, new ConfigCatClientErrorEventArgs(message, exception));
+            Error?.Invoke(client, new ConfigCatClientErrorEventArgs(message.InvariantFormattedMessage, exception));
         }
 
         public override event EventHandler<ClientReadyEventArgs>? ClientReady;

--- a/src/ConfigCatClient/Hooks/SafeHooksWrapper.cs
+++ b/src/ConfigCatClient/Hooks/SafeHooksWrapper.cs
@@ -37,8 +37,8 @@ internal readonly struct SafeHooksWrapper
         => Hooks.RaiseConfigChanged(newConfig);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public void RaiseError(string message, Exception? exception)
-        => Hooks.RaiseError(message, exception);
+    public void RaiseError(ref FormattableLogMessage message, Exception? exception)
+        => Hooks.RaiseError(ref message, exception);
 
     public static implicit operator SafeHooksWrapper(Hooks? hooks) => hooks is not null ? new SafeHooksWrapper(hooks) : default;
 }

--- a/src/ConfigCatClient/HttpConfigFetcher.cs
+++ b/src/ConfigCatClient/HttpConfigFetcher.cs
@@ -90,7 +90,7 @@ internal sealed class HttpConfigFetcher : IConfigFetcher, IDisposable
                     {
                         var exception = responseWithBody.Exception;
                         logMessage = this.logger.FetchReceived200WithInvalidBody(exception);
-                        return FetchResult.Failure(lastConfig, RefreshErrorCode.InvalidHttpResponseContent, logMessage.InvariantFormattedMessage, exception);
+                        return FetchResult.Failure(lastConfig, RefreshErrorCode.InvalidHttpResponseContent, logMessage.ToLazyString(), exception);
                     }
 
                     return FetchResult.Success(new ProjectConfig
@@ -105,7 +105,7 @@ internal sealed class HttpConfigFetcher : IConfigFetcher, IDisposable
                     if (lastConfig.IsEmpty)
                     {
                         logMessage = this.logger.FetchReceived304WhenLocalCacheIsEmpty((int)response.StatusCode, response.ReasonPhrase);
-                        return FetchResult.Failure(lastConfig, RefreshErrorCode.InvalidHttpResponseWhenLocalCacheIsEmpty, logMessage.InvariantFormattedMessage);
+                        return FetchResult.Failure(lastConfig, RefreshErrorCode.InvalidHttpResponseWhenLocalCacheIsEmpty, logMessage.ToLazyString());
                     }
 
                     return FetchResult.NotModified(lastConfig.With(ProjectConfig.GenerateTimeStamp()));
@@ -115,13 +115,13 @@ internal sealed class HttpConfigFetcher : IConfigFetcher, IDisposable
                     logMessage = this.logger.FetchFailedDueToInvalidSdkKey();
 
                     // We update the timestamp for extra protection against flooding.
-                    return FetchResult.Failure(lastConfig.With(ProjectConfig.GenerateTimeStamp()), RefreshErrorCode.InvalidSdkKey, logMessage.InvariantFormattedMessage);
+                    return FetchResult.Failure(lastConfig.With(ProjectConfig.GenerateTimeStamp()), RefreshErrorCode.InvalidSdkKey, logMessage.ToLazyString());
 
                 default:
                     logMessage = this.logger.FetchFailedDueToUnexpectedHttpResponse((int)response.StatusCode, response.ReasonPhrase);
 
                     ReInitializeHttpClient();
-                    return FetchResult.Failure(lastConfig, RefreshErrorCode.UnexpectedHttpResponse, logMessage.InvariantFormattedMessage);
+                    return FetchResult.Failure(lastConfig, RefreshErrorCode.UnexpectedHttpResponse, logMessage.ToLazyString());
             }
         }
         catch (OperationCanceledException) when (this.cancellationTokenSource.IsCancellationRequested)
@@ -153,7 +153,7 @@ internal sealed class HttpConfigFetcher : IConfigFetcher, IDisposable
         }
 
         ReInitializeHttpClient();
-        return FetchResult.Failure(lastConfig, errorCode, logMessage.InvariantFormattedMessage, errorException);
+        return FetchResult.Failure(lastConfig, errorCode, logMessage.ToLazyString(), errorException);
     }
 
     private async ValueTask<ResponseWithBody> FetchRequestAsync(string? httpETag, Uri requestUri, sbyte maxExecutionCount = 3)

--- a/src/ConfigCatClient/Logging/FormattableLogMessage.cs
+++ b/src/ConfigCatClient/Logging/FormattableLogMessage.cs
@@ -72,6 +72,13 @@ public struct FormattableLogMessage : IFormattable
     /// </summary>
     public string InvariantFormattedMessage => this.invariantFormattedMessage ??= ToString(CultureInfo.InvariantCulture);
 
+    internal LazyString ToLazyString()
+    {
+        return this.invariantFormattedMessage is { } invariantFormattedMessage
+            ? invariantFormattedMessage
+            : new LazyString(this.format ?? string.Empty, this.argValues);
+    }
+
     /// <summary>
     /// Returns the log message formatted using <see cref="CultureInfo.CurrentCulture"/>.
     /// </summary>

--- a/src/ConfigCatClient/Logging/FormattableLogMessage.cs
+++ b/src/ConfigCatClient/Logging/FormattableLogMessage.cs
@@ -14,7 +14,7 @@ public struct FormattableLogMessage : IFormattable
         return message.Replace("{", "{{").Replace("}", "}}");
     }
 
-    internal static FormattableLogMessage FromInterpolated(FormattableString message, string[] argNames)
+    internal static FormattableLogMessage FromInterpolated(ValueFormattableString message, string[] argNames)
     {
         return new FormattableLogMessage(message.Format,
             argNames ?? ArrayUtils.EmptyArray<string>(),

--- a/src/ConfigCatClient/Logging/IConfigCatLogger.cs
+++ b/src/ConfigCatClient/Logging/IConfigCatLogger.cs
@@ -9,7 +9,7 @@ namespace ConfigCat.Client;
 /// <param name="eventId">Event identifier.</param>
 /// <param name="message">Message.</param>
 /// <param name="exception">The <see cref="Exception"/> object related to the message (if any).</param>
-/// <returns><see langword="true"/> when the event should be logged, <see langword="false"/> when it should be suppressed.</returns>
+/// <returns><see langword="true"/> when the event should be logged, <see langword="false"/> when it should be skipped.</returns>
 public delegate bool LogFilterCallback(LogLevel level, LogEventId eventId, ref FormattableLogMessage message, Exception? exception);
 
 /// <summary>

--- a/src/ConfigCatClient/Logging/IConfigCatLogger.cs
+++ b/src/ConfigCatClient/Logging/IConfigCatLogger.cs
@@ -3,6 +3,16 @@ using System;
 namespace ConfigCat.Client;
 
 /// <summary>
+/// Represents a method that is called by the SDK to decide whether a log event should be logged.
+/// </summary>
+/// <param name="level">Event severity level.</param>
+/// <param name="eventId">Event identifier.</param>
+/// <param name="message">Message.</param>
+/// <param name="exception">The <see cref="Exception"/> object related to the message (if any).</param>
+/// <returns><see langword="true"/> when the event should be logged, <see langword="false"/> when it should be suppressed.</returns>
+public delegate bool LogFilterCallback(LogLevel level, LogEventId eventId, ref FormattableLogMessage message, Exception? exception);
+
+/// <summary>
 /// Defines the interface used by the ConfigCat SDK to perform logging.
 /// </summary>
 public interface IConfigCatLogger

--- a/src/ConfigCatClient/Logging/LogMessages.cs
+++ b/src/ConfigCatClient/Logging/LogMessages.cs
@@ -1,5 +1,6 @@
 using System;
 using ConfigCat.Client.ConfigService;
+using ConfigCat.Client.Utils;
 
 namespace ConfigCat.Client;
 
@@ -17,7 +18,7 @@ internal static partial class LoggerExtensions
         $"Config JSON is not present when evaluating setting '{key}'. Returning the `{defaultParamName}` parameter that you specified in your application: '{defaultParamValue}'.",
         "KEY", "DEFAULT_PARAM_NAME", "DEFAULT_PARAM_VALUE");
 
-    public static FormattableLogMessage SettingEvaluationFailedDueToMissingKey(this LoggerWrapper logger, string key, string defaultParamName, object? defaultParamValue, string availableKeys) => logger.LogInterpolated(
+    public static FormattableLogMessage SettingEvaluationFailedDueToMissingKey(this LoggerWrapper logger, string key, string defaultParamName, object? defaultParamValue, StringListFormatter availableKeys) => logger.LogInterpolated(
         LogLevel.Error, 1001,
         $"Failed to evaluate setting '{key}' (the key was not found in config JSON). Returning the `{defaultParamName}` parameter that you specified in your application: '{defaultParamValue}'. Available keys: [{availableKeys}].",
         "KEY", "DEFAULT_PARAM_NAME", "DEFAULT_PARAM_VALUE", "AVAILABLE_KEYS");

--- a/src/ConfigCatClient/Logging/LoggerExtensions.cs
+++ b/src/ConfigCatClient/Logging/LoggerExtensions.cs
@@ -46,12 +46,12 @@ internal static partial class LoggerExtensions
     // `logger.Log(LogLevel.Error, 1234, "A message with {PARAM}", paramValue)`
     // but then we'd need to manually parse the format string, which is better to avoid to keep our solution simple.)
 
-    public static FormattableLogMessage LogInterpolated(this LoggerWrapper logger, LogLevel level, LogEventId eventId, FormattableString message, params string[] argNames)
+    public static FormattableLogMessage LogInterpolated(this LoggerWrapper logger, LogLevel level, LogEventId eventId, ValueFormattableString message, params string[] argNames)
     {
         return LogInterpolated(logger, level, eventId, exception: null, message, argNames);
     }
 
-    public static FormattableLogMessage LogInterpolated(this LoggerWrapper logger, LogLevel level, LogEventId eventId, Exception? exception, FormattableString message, params string[] argNames)
+    public static FormattableLogMessage LogInterpolated(this LoggerWrapper logger, LogLevel level, LogEventId eventId, Exception? exception, ValueFormattableString message, params string[] argNames)
     {
         if (logger is null)
         {

--- a/src/ConfigCatClient/Logging/LoggerWrapper.cs
+++ b/src/ConfigCatClient/Logging/LoggerWrapper.cs
@@ -1,10 +1,12 @@
 using System;
+using ConfigCat.Client.Configuration;
 
 namespace ConfigCat.Client;
 
 internal sealed class LoggerWrapper : IConfigCatLogger
 {
     private readonly IConfigCatLogger logger;
+    private readonly LogFilterCallback? filter;
     private readonly SafeHooksWrapper hooks;
 
     public LogLevel LogLevel
@@ -13,9 +15,10 @@ internal sealed class LoggerWrapper : IConfigCatLogger
         set => this.logger.LogLevel = value;
     }
 
-    internal LoggerWrapper(IConfigCatLogger logger, SafeHooksWrapper hooks = default)
+    internal LoggerWrapper(IConfigCatLogger logger, LogFilterCallback? filter = null, SafeHooksWrapper hooks = default)
     {
         this.logger = logger;
+        this.filter = filter;
         this.hooks = hooks;
     }
 
@@ -27,7 +30,7 @@ internal sealed class LoggerWrapper : IConfigCatLogger
     /// <inheritdoc />
     public void Log(LogLevel level, LogEventId eventId, ref FormattableLogMessage message, Exception? exception = null)
     {
-        if (IsEnabled(level))
+        if (IsEnabled(level) && (this.filter is null || this.filter(level, eventId, ref message, exception)))
         {
             this.logger.Log(level, eventId, ref message, exception);
         }

--- a/src/ConfigCatClient/Logging/LoggerWrapper.cs
+++ b/src/ConfigCatClient/Logging/LoggerWrapper.cs
@@ -37,7 +37,7 @@ internal sealed class LoggerWrapper : IConfigCatLogger
 
         if (level == LogLevel.Error)
         {
-            this.hooks.RaiseError(message.InvariantFormattedMessage, exception);
+            this.hooks.RaiseError(ref message, exception);
         }
     }
 }

--- a/src/ConfigCatClient/RefreshResult.cs
+++ b/src/ConfigCatClient/RefreshResult.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
+using ConfigCat.Client.Utils;
 
 namespace ConfigCat.Client;
 
@@ -29,17 +30,24 @@ public readonly struct RefreshResult
             errorException);
     }
 
+    internal static RefreshResult Failure(RefreshErrorCode errorCode, LazyString errorMessage, Exception? errorException = null)
+    {
+        return new RefreshResult(errorCode, errorMessage, errorException);
+    }
+
     internal static RefreshResult From(in FetchResult fetchResult)
     {
         return !fetchResult.IsFailure
             ? Success()
-            : Failure(fetchResult.ErrorCode, fetchResult.ErrorMessage, fetchResult.ErrorException);
+            : new RefreshResult(fetchResult.ErrorCode, fetchResult.ErrorMessage, fetchResult.ErrorException);
     }
 
-    private RefreshResult(RefreshErrorCode errorCode, string? errorMessage, Exception? errorException)
+    private readonly object? errorMessage; // either null or a string or a boxed LazyString
+
+    private RefreshResult(RefreshErrorCode errorCode, object? errorMessage, Exception? errorException)
     {
         ErrorCode = errorCode;
-        ErrorMessage = errorMessage;
+        this.errorMessage = errorMessage;
         ErrorException = errorException;
     }
 
@@ -57,7 +65,7 @@ public readonly struct RefreshResult
     /// <summary>
     /// Error message in case the operation failed, otherwise <see langword="null" />.
     /// </summary>
-    public string? ErrorMessage { get; }
+    public string? ErrorMessage => this.errorMessage?.ToString();
 
     /// <summary>
     /// The <see cref="Exception"/> object related to the error in case the operation failed (if any).

--- a/src/ConfigCatClient/Utils/IndentedTextBuilder.cs
+++ b/src/ConfigCatClient/Utils/IndentedTextBuilder.cs
@@ -48,7 +48,7 @@ internal sealed class IndentedTextBuilder
     }
 
 #if !NET6_0_OR_GREATER
-    public IndentedTextBuilder Append(FormattableString value)
+    public IndentedTextBuilder Append(ValueFormattableString value)
     {
         this.stringBuilder.AppendFormat(CultureInfo.InvariantCulture, value.Format, value.GetArguments());
         return this;

--- a/src/ConfigCatClient/Utils/LazyString.cs
+++ b/src/ConfigCatClient/Utils/LazyString.cs
@@ -1,0 +1,42 @@
+using System.Globalization;
+
+namespace ConfigCat.Client.Utils;
+
+internal struct LazyString
+{
+    private readonly string? format;
+    private object? argsOrValue;
+
+    public LazyString(string? value)
+    {
+        this.format = null;
+        this.argsOrValue = value;
+    }
+
+    public LazyString(string format, params object?[]? args)
+    {
+        this.format = format;
+        this.argsOrValue = args ?? ArrayUtils.EmptyArray<string>();
+    }
+
+    public string? Value => this.argsOrValue as string;
+
+    public override string? ToString()
+    {
+        var argsOrValue = this.argsOrValue;
+        if (argsOrValue is null)
+        {
+            return null;
+        }
+
+        if (argsOrValue is not string value)
+        {
+            var args = (object?[])argsOrValue;
+            this.argsOrValue = value = string.Format(CultureInfo.InvariantCulture, this.format!, args);
+        }
+
+        return value;
+    }
+
+    public static implicit operator LazyString(string? value) => new LazyString(value);
+}


### PR DESCRIPTION
### Describe the purpose of your pull request

Provides a new, more convenient way  (`ConfigCatClientOptions.LogFilter`) for consumers to specify custom log event filter logic.

Also, brings some performance improvements (reduced memory allocation) around log messages and evaluation log building:

## ConfigCat.Client.Benchmarks.MatrixTestBenchmark

| **Diff**|Method|Mean|Error|Allocated|
|------- |-------|-------:|-------|-------:|
| Old (net6.0, LogInfo = false) |MatrixTests_ConfigV6|16.14 ms|0.149 ms|11.75 MB|
| **New** (net6.0, LogInfo = false) |	| **16.17 ms (0%)** | **0.084 ms** | **11.53 MB (-2%)** |
| Old (net48, LogInfo = false) |MatrixTests_ConfigV6|52.67 ms|0.157 ms|17.33 MB|
| **New** (net48, LogInfo = false) |	| **52.53 ms (0%)** | **0.318 ms** | **16.77 MB (-3%)** |
| Old (net6.0, LogInfo = true) |MatrixTests_ConfigV6|49.48 ms|0.204 ms|62.76 MB|
| **New** (net6.0, LogInfo = true) |	| **48.92 ms (-1%)** | **0.444 ms** | **62.07 MB (-1%)** |
| Old (net48, LogInfo = true) |MatrixTests_ConfigV6|138.43 ms|1.004 ms|77.65 MB|
| **New** (net48, LogInfo = true) |	| **136.28 ms (-2%)** | **0.842 ms** | **73.94 MB (-5%)** |

### Related issues (only if applicable)

https://trello.com/c/IxCFbq2j

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
