### PR TITLE
Fix cache expiration-related issues in Auto Polling mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Based on our tests, the SDK is compatible with the following runtimes/deployment
 <sup><small>*</small></sup>Unity WebGL also works but needs a bit of extra effort: you will need to enable WebGL compatibility by calling the `ConfigCatClient.PlatformCompatibilityOptions.EnableUnityWebGLCompatibility` method. For more details, see [Sample Scripts](https://github.com/configcat/.net-sdk/tree/master/samples/UnityWebGL).<br/>
 <sup><small>**</small></sup>To make the SDK work in Release builds on UWP, you will need to add `<Namespace Name="System.Text.Json.Serialization.Converters" Browse="Required All"/>` to your application's [.rd.xml](https://learn.microsoft.com/en-us/windows/uwp/dotnet-native/runtime-directives-rd-xml-configuration-file-reference) file. See also [this discussion](https://github.com/dotnet/runtime/issues/29912#issuecomment-638471351).
 
-We strive to provide an extensive support for the various .NET runtimes and versions. If you still encounter an issue with the SDK on some platform, please open a [GitHub issue](https://github.com/configcat/.net-sdk/issues/new/choose) or contact support.
+> We strive to provide an extensive support for the various .NET runtimes and versions. If you still encounter an issue with the SDK on some platform, please open a [GitHub issue](https://github.com/configcat/.net-sdk/issues/new/choose) or contact support.
 
 ## Need help?
 https://configcat.com/support

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  build_version: 9.3.0
+  build_version: 9.3.1
 version: $(build_version)-{build}
 image: Visual Studio 2022
 configuration: Release


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR fixes multiple issues in Auto Polling mode:
* Cache expiration should be checked in every poll iteration, not just in the first one to reduce network traffic when the SDK uses a shared cache.
* Cache synchronization should happen even in offline mode in every poll iteration, not just in the first one to update in-memory cache when the SDK uses a shared cache.

### Related issues (only if applicable)

https://trello.com/c/gnqqRydc

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
