### PR TITLE
Fix ConfigCatToMSLoggerAdapter to work with Serilog

### DIFF
--- a/samples/ASP.NETCore/WebApplication/Program.cs
+++ b/samples/ASP.NETCore/WebApplication/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 var builder = Microsoft.AspNetCore.Builder.WebApplication.CreateBuilder(args);
 

--- a/src/ConfigCatClient/Evaluation/RolloutEvaluator.cs
+++ b/src/ConfigCatClient/Evaluation/RolloutEvaluator.cs
@@ -364,7 +364,7 @@ internal sealed class RolloutEvaluator : IRolloutEvaluator
 
         if (userAttributeValue is null || userAttributeValue is string { Length: 0 })
         {
-            this.logger.UserObjectAttributeIsMissing(condition.ToString(), context.Key, userAttributeName);
+            this.logger.UserObjectAttributeIsMissing(condition, context.Key, userAttributeName);
             error = string.Format(CultureInfo.InvariantCulture, MissingUserAttributeError, userAttributeName);
             return false;
         }
@@ -908,7 +908,7 @@ internal sealed class RolloutEvaluator : IRolloutEvaluator
         }
 
         text = UserAttributeValueToString(attributeValue);
-        this.logger.UserObjectAttributeIsAutoConverted(condition.ToString(), key, attributeName, text);
+        this.logger.UserObjectAttributeIsAutoConverted(condition, key, attributeName, text);
         return text;
     }
 
@@ -973,7 +973,7 @@ internal sealed class RolloutEvaluator : IRolloutEvaluator
 
     private string HandleInvalidUserAttribute(UserCondition condition, string key, string attributeName, string reason)
     {
-        this.logger.UserObjectAttributeIsInvalid(condition.ToString(), key, reason, attributeName);
+        this.logger.UserObjectAttributeIsInvalid(condition, key, reason, attributeName);
         return string.Format(CultureInfo.InvariantCulture, InvalidUserAttributeError, attributeName, reason);
     }
 }

--- a/src/ConfigCatClient/Logging/FormattableLogMessage.cs
+++ b/src/ConfigCatClient/Logging/FormattableLogMessage.cs
@@ -74,9 +74,8 @@ public struct FormattableLogMessage : IFormattable
 
     internal LazyString ToLazyString()
     {
-        return this.invariantFormattedMessage is { } invariantFormattedMessage
-            ? invariantFormattedMessage
-            : new LazyString(this.format ?? string.Empty, this.argValues);
+        return this.invariantFormattedMessage
+            ?? new LazyString(this.format ?? string.Empty, this.argValues);
     }
 
     /// <summary>

--- a/src/ConfigCatClient/Logging/LogMessages.cs
+++ b/src/ConfigCatClient/Logging/LogMessages.cs
@@ -157,17 +157,17 @@ internal static partial class LoggerExtensions
         $"Cannot evaluate % options for setting '{key}' (the User.{attributeName} attribute is missing). You should set the User.{attributeName} attribute in order to make targeting work properly. Read more: https://configcat.com/docs/advanced/user-object/",
         "KEY", "ATTRIBUTE_NAME", "ATTRIBUTE_NAME");
 
-    public static FormattableLogMessage UserObjectAttributeIsMissing(this LoggerWrapper logger, string condition, string key, string attributeName) => logger.LogInterpolated(
+    public static FormattableLogMessage UserObjectAttributeIsMissing(this LoggerWrapper logger, UserCondition condition, string key, string attributeName) => logger.LogInterpolated(
         LogLevel.Warning, 3003,
         $"Cannot evaluate condition ({condition}) for setting '{key}' (the User.{attributeName} attribute is missing). You should set the User.{attributeName} attribute in order to make targeting work properly. Read more: https://configcat.com/docs/advanced/user-object/",
         "CONDITION", "KEY", "ATTRIBUTE_NAME", "ATTRIBUTE_NAME");
 
-    public static FormattableLogMessage UserObjectAttributeIsInvalid(this LoggerWrapper logger, string condition, string key, string reason, string attributeName) => logger.LogInterpolated(
+    public static FormattableLogMessage UserObjectAttributeIsInvalid(this LoggerWrapper logger, UserCondition condition, string key, string reason, string attributeName) => logger.LogInterpolated(
         LogLevel.Warning, 3004,
         $"Cannot evaluate condition ({condition}) for setting '{key}' ({reason}). Please check the User.{attributeName} attribute and make sure that its value corresponds to the comparison operator.",
         "CONDITION", "KEY", "REASON", "ATTRIBUTE_NAME");
 
-    public static FormattableLogMessage UserObjectAttributeIsAutoConverted(this LoggerWrapper logger, string condition, string key, string attributeName, string attributeValue) => logger.LogInterpolated(
+    public static FormattableLogMessage UserObjectAttributeIsAutoConverted(this LoggerWrapper logger, UserCondition condition, string key, string attributeName, string attributeValue) => logger.LogInterpolated(
         LogLevel.Warning, 3005,
         $"Evaluation of condition ({condition}) for setting '{key}' may not produce the expected result (the User.{attributeName} attribute is not a string value, thus it was automatically converted to the string value '{attributeValue}'). Please make sure that using a non-string value was intended.",
         "CONDITION", "KEY", "ATTRIBUTE_NAME", "ATTRIBUTE_VALUE");


### PR DESCRIPTION
### Describe the purpose of your pull request

When using `ConfigCatToMSLoggerAdapter` with Serilog, log message strings are not formatted. This is because Serilog parses the message format string under the hood and expects named parameters instead of positional ones.

This PR makes changes to the adapter so it converts positional parameters to named parameters.

Also, revises the adapter and
* corrects it to use invariant culture for formatting (as MS.Extensions.Logging and Serilog does),
* does some micro-optimization (including changing LogValues to a value type to avoid an extra heap memory allocation for each log event).

### Related issues (only if applicable)
#106

### How to test? (only if applicable)
n/a

### Security (only if applicable)
n/a

### Requirement checklist (only if applicable)
- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
