### PR TITLE
Correct pending request vs. Dispose behavior in HttpClientConfigFetcher

### DIFF
--- a/src/ConfigCatClient/ConfigService/ConfigServiceBase.cs
+++ b/src/ConfigCatClient/ConfigService/ConfigServiceBase.cs
@@ -64,9 +64,9 @@ internal abstract class ConfigServiceBase : IDisposable
 
     protected virtual void Dispose(bool disposing)
     {
-        if (disposing && this.ConfigFetcher is IDisposable disposable)
+        if (disposing)
         {
-            disposable.Dispose();
+            (this.ConfigFetcher as IDisposable)?.Dispose();
         }
     }
 

--- a/src/ConfigCatClient/ConfigService/DefaultConfigFetcher.cs
+++ b/src/ConfigCatClient/ConfigService/DefaultConfigFetcher.cs
@@ -93,6 +93,10 @@ internal sealed class DefaultConfigFetcher : IConfigFetcher, IDisposable
                     return FetchResult.Failure(lastConfig, RefreshErrorCode.UnexpectedHttpResponse, logMessage.ToLazyString());
             }
         }
+        catch (ObjectDisposedException ex)
+        {
+            throw new OperationCanceledException(message: null, ex);
+        }
         catch (OperationCanceledException)
         {
             throw;

--- a/src/ConfigCatClient/ConfigService/FetchResult.cs
+++ b/src/ConfigCatClient/ConfigService/FetchResult.cs
@@ -8,7 +8,7 @@ namespace ConfigCat.Client;
 
 internal readonly struct FetchResult
 {
-    private static readonly object NotModifiedToken = new();
+    private static readonly object NotModifiedToken = false.AsCachedObject();
 
     public static FetchResult Success(ProjectConfig config)
     {


### PR DESCRIPTION
### Describe the purpose of your pull request
The implementation of `HttpClientConfigFetcher` is somewhat sloppy currently because
* it doesn't correctly handle the race condition between `Dispose` and `FetchAsync`, which are not (and can't really be) synchronized,
* it allows creation of new `HttpClient` instances after `Dispose`.

This PR tightens things up in this area.

### Related issues (only if applicable)
n/a

### How to test? (only if applicable)
n/a

### Security (only if applicable)
n/a

### Requirement checklist (only if applicable)
- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
