### PR TITLE
Clean up config model

### DIFF
--- a/benchmarks/NewVersionLib/BenchmarkHelper.Shared.cs
+++ b/benchmarks/NewVersionLib/BenchmarkHelper.Shared.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using ConfigCat.Client.Evaluation;
+using ConfigCat.Client.Tests.Helpers;
 
 #if BENCHMARK_OLD
 namespace ConfigCat.Client.Benchmarks.Old;
@@ -46,12 +47,12 @@ public static partial class BenchmarkHelper
     public static EvaluationDetails<T> Evaluate<T>(object evaluationServices, string key, T defaultValue, User? user = null)
     {
         var services = (EvaluationServices)evaluationServices;
-        return services.Evaluator.Evaluate(Config.Settings, key, defaultValue, user, remoteConfig: null, services.Logger);
+        return services.Evaluator.Evaluate(Config.GetSettings(), key, defaultValue, user, remoteConfig: null, services.Logger);
     }
 
     public static EvaluationDetails[] EvaluateAll(object evaluationServices, User? user = null)
     {
         var services = (EvaluationServices)evaluationServices;
-        return services.Evaluator.EvaluateAll(Config.Settings, user, remoteConfig: null, services.Logger, "empty array", out _);
+        return services.Evaluator.EvaluateAll(Config.GetSettings(), user, remoteConfig: null, services.Logger, "empty array", out _);
     }
 }

--- a/benchmarks/NewVersionLib/BenchmarkHelper.cs
+++ b/benchmarks/NewVersionLib/BenchmarkHelper.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using ConfigCat.Client.Tests.Helpers;
 
 namespace ConfigCat.Client.Benchmarks.New;
@@ -15,32 +17,32 @@ public static partial class BenchmarkHelper
     {
         var config = new Config
         {
-            Preferences = new Preferences
+            preferences = new Preferences
             {
                 Salt = "LKQu1a62agfNnWuGwA8cZglf4x0yZSbY2En7WQn5dWw"
             },
-            Settings =
+            settings = new Dictionary<string, Setting>()
             {
                 ["basicFlag"] = new Setting
                 {
-                    SettingType = SettingType.Boolean,
-                    Value = new SettingValue { BoolValue = true },
+                    settingType = SettingType.Boolean,
+                    value = new SettingValue { BoolValue = true },
                 },
                 ["complexFlag"] = new Setting
                 {
-                    SettingType = SettingType.String,
-                    TargetingRules = new[]
+                    settingType = SettingType.String,
+                    targetingRules = new[]
                     {
                         new TargetingRule
                         {
-                            Conditions = new[]
+                            conditions = new[]
                             {
                                 new ConditionContainer
                                 {
                                     UserCondition =  new UserCondition()
                                     {
-                                        ComparisonAttribute = nameof(User.Identifier),
-                                        Comparator = UserComparator.SensitiveTextIsOneOf,
+                                        comparisonAttribute = nameof(User.Identifier),
+                                        comparator = UserComparator.SensitiveTextIsOneOf,
                                         StringListValue = new[]
                                         {
                                             "61418c941ecda8031d08ab86ec821e676fde7b6a59cd16b1e7191503c2f8297d",
@@ -49,100 +51,100 @@ public static partial class BenchmarkHelper
                                     }
                                 },
                             },
-                            SimpleValue = new SimpleSettingValue { Value = new SettingValue { StringValue =  "a" } },
+                            SimpleValueOrNull = new SimpleSettingValue { value = new SettingValue { StringValue =  "a" } },
                         },
                         new TargetingRule
                         {
-                            Conditions = new[]
+                            conditions = new[]
                             {
                                 new ConditionContainer
                                 {
                                     UserCondition =  new UserCondition()
                                     {
-                                        ComparisonAttribute = nameof(User.Email),
-                                        Comparator = UserComparator.TextContainsAnyOf,
+                                        comparisonAttribute = nameof(User.Email),
+                                        comparator = UserComparator.TextContainsAnyOf,
                                         StringListValue = new[] { "@example.com" }
                                     }
                                 },
                             },
-                            SimpleValue = new SimpleSettingValue { Value = new SettingValue { StringValue =  "b" } },
+                            SimpleValueOrNull = new SimpleSettingValue { value = new SettingValue { StringValue =  "b" } },
                         },
                         new TargetingRule
                         {
-                            Conditions = new[]
+                            conditions = new[]
                             {
                                 new ConditionContainer
                                 {
                                     UserCondition =  new UserCondition()
                                     {
-                                        ComparisonAttribute = "Version",
-                                        Comparator = UserComparator.SemVerIsOneOf,
+                                        comparisonAttribute = "Version",
+                                        comparator = UserComparator.SemVerIsOneOf,
                                         StringListValue = new[] { "1.0.0", "2.0.0" }
                                     }
                                 },
                             },
-                            SimpleValue = new SimpleSettingValue { Value = new SettingValue { StringValue =  "c" } },
+                            SimpleValueOrNull = new SimpleSettingValue { value = new SettingValue { StringValue =  "c" } },
                         },
                         new TargetingRule
                         {
-                            Conditions = new[]
+                            conditions = new[]
                             {
                                 new ConditionContainer
                                 {
                                     UserCondition =  new UserCondition()
                                     {
-                                        ComparisonAttribute = "Version",
-                                        Comparator = UserComparator.SemVerGreater,
+                                        comparisonAttribute = "Version",
+                                        comparator = UserComparator.SemVerGreater,
                                         StringValue = "3.0.0"
                                     }
                                 },
                             },
-                            SimpleValue = new SimpleSettingValue { Value = new SettingValue { StringValue =  "d" } },
+                            SimpleValueOrNull = new SimpleSettingValue { value = new SettingValue { StringValue =  "d" } },
                         },
                         new TargetingRule
                         {
-                            Conditions = new[]
+                            conditions = new[]
                             {
                                 new ConditionContainer
                                 {
                                     UserCondition =  new UserCondition()
                                     {
-                                        ComparisonAttribute = "Number",
-                                        Comparator = UserComparator.NumberGreater,
+                                        comparisonAttribute = "Number",
+                                        comparator = UserComparator.NumberGreater,
                                         DoubleValue = 3.14
                                     }
                                 },
                             },
-                            SimpleValue = new SimpleSettingValue { Value = new SettingValue { StringValue =  "e" } },
+                            SimpleValueOrNull = new SimpleSettingValue { value = new SettingValue { StringValue =  "e" } },
                         },
                         new TargetingRule
                         {
-                            PercentageOptions = new[]
+                            PercentageOptionsOrNull = new[]
                             {
                                 new PercentageOption
                                 {
-                                    Percentage = 20,
-                                    Value = new SettingValue { StringValue =  "p20" }
+                                    percentage = 20,
+                                    value = new SettingValue { StringValue =  "p20" }
                                 },
                                 new PercentageOption
                                 {
-                                    Percentage = 30,
-                                    Value = new SettingValue { StringValue =  "p30" }
+                                    percentage = 30,
+                                    value = new SettingValue { StringValue =  "p30" }
                                 },
                                 new PercentageOption
                                 {
-                                    Percentage = 50,
-                                    Value = new SettingValue { StringValue =  "p50" }
+                                    percentage = 50,
+                                    value = new SettingValue { StringValue =  "p50" }
                                 },
                             }
                         },
                     },
-                    Value = new SettingValue { StringValue =  "fallback" }
+                    value = new SettingValue { StringValue = "fallback" }
                 }
             }
         };
 
-        config.OnDeserialized();
+        ((IJsonOnDeserialized)config).OnDeserialized();
         return config;
     })();
 }

--- a/benchmarks/NewVersionLib/ConfigHelper.cs
+++ b/benchmarks/NewVersionLib/ConfigHelper.cs
@@ -2,9 +2,18 @@
 using Config = ConfigCat.Client.SettingsWithPreferences;
 #endif
 
+using System.Collections.Generic;
+
 namespace ConfigCat.Client.Tests.Helpers;
 
 internal static class ConfigHelper
 {
+    public static Dictionary<string, Setting> GetSettings(this Config config) =>
+#if BENCHMARK_OLD
+        config.Settings;
+#else
+        config.SettingsOrEmpty;
+#endif
+
     public static Config FetchConfigCached(this ConfigLocation location) => location.FetchConfig();
 }

--- a/benchmarks/OldVersionLib/OldVersionLib.csproj
+++ b/benchmarks/OldVersionLib/OldVersionLib.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="ConfigCat.Client" Version="8.2.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" Condition="'$(TargetFramework)' == 'net48'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ConfigCat.Client.Tests/ConfigCacheTests.cs
+++ b/src/ConfigCat.Client.Tests/ConfigCacheTests.cs
@@ -214,7 +214,7 @@ public class ConfigCacheTests
     public void CachePayloadSerialization_ShouldBePlatformIndependent(string configJson, string timeStamp, string httpETag, string expectedPayload)
     {
         var timeStampDateTime = DateTimeOffset.ParseExact(timeStamp, "o", CultureInfo.InvariantCulture).UtcDateTime;
-        var pc = new ProjectConfig(configJson, Config.Deserialize(configJson.AsSpan()), timeStampDateTime, httpETag);
+        var pc = new ProjectConfig(configJson, Config.Deserialize(configJson.AsSpan(), tolerant: false), timeStampDateTime, httpETag);
 
         Assert.AreEqual(expectedPayload, ProjectConfig.Serialize(pc));
     }

--- a/src/ConfigCat.Client.Tests/ConfigCat.Client.Tests.csproj
+++ b/src/ConfigCat.Client.Tests/ConfigCat.Client.Tests.csproj
@@ -10,7 +10,7 @@
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
     <NoWarn>CS1685;NU1902;NU1903</NoWarn>
-    <SuppressTfmSupportBuildWarnings Condition="'$(TargetFramework)' == 'netcoreapp2.1'">true</SuppressTfmSupportBuildWarnings>
+    <SuppressTfmSupportBuildWarnings Condition="'$(TargetFramework)' == 'netcoreapp2.1' OR '$(TargetFramework)' == 'netcoreapp3.1'">true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <Choose>

--- a/src/ConfigCat.Client.Tests/ConfigV2EvaluationTests.cs
+++ b/src/ConfigCat.Client.Tests/ConfigV2EvaluationTests.cs
@@ -233,7 +233,7 @@ public class ConfigV2EvaluationTests : EvaluationTestsBase
         var logger = new Mock<IConfigCatLogger>().Object.AsWrapper();
         var evaluator = new RolloutEvaluator(logger);
 
-        var ex = Assert.ThrowsException<InvalidConfigModelException>(() => evaluator.Evaluate<object?>(config!.Settings, key, defaultValue: null, user: null, remoteConfig: null, logger));
+        var ex = Assert.ThrowsException<InvalidConfigModelException>(() => evaluator.Evaluate<object?>(config!.SettingsOrEmpty, key, defaultValue: null, user: null, remoteConfig: null, logger));
 
         StringAssert.Contains(ex.Message, "Circular dependency detected");
         StringAssert.Contains(ex.Message, dependencyCycle);
@@ -407,7 +407,7 @@ public class ConfigV2EvaluationTests : EvaluationTestsBase
 
         var user = userId is not null ? new User(userId) { Email = email, Custom = { ["PercentageBase"] = percentageBase! } } : null;
 
-        var evaluationDetails = evaluator.Evaluate<object?>(config!.Settings, key, defaultValue: null, user, remoteConfig: null, logger);
+        var evaluationDetails = evaluator.Evaluate<object?>(config!.SettingsOrEmpty, key, defaultValue: null, user, remoteConfig: null, logger);
 
         Assert.AreEqual(expectedReturnValue, evaluationDetails.Value);
         Assert.AreEqual(expectedIsExpectedMatchedTargetingRuleSet, evaluationDetails.MatchedTargetingRule is not null);
@@ -428,7 +428,7 @@ public class ConfigV2EvaluationTests : EvaluationTestsBase
         var user = new User("12345") { Custom = { [customAttributeName] = customAttributeValue } };
 
         const string key = "boolTextEqualsNumber";
-        var evaluationDetails = evaluator.Evaluate<bool?>(config!.Settings, key, defaultValue: null, user, remoteConfig: null, logger);
+        var evaluationDetails = evaluator.Evaluate<bool?>(config!.SettingsOrEmpty, key, defaultValue: null, user, remoteConfig: null, logger);
 
         Assert.AreEqual(true, evaluationDetails.Value);
 
@@ -588,7 +588,7 @@ public class ConfigV2EvaluationTests : EvaluationTestsBase
 
         var user = userId is not null ? new User(userId) { Custom = { [customAttributeName] = customAttributeValue! } } : null;
 
-        var evaluationDetails = evaluator.Evaluate<object?>(config!.Settings, key, defaultValue: null, user, remoteConfig: null, logger);
+        var evaluationDetails = evaluator.Evaluate<object?>(config!.SettingsOrEmpty, key, defaultValue: null, user, remoteConfig: null, logger);
 
         Assert.AreEqual(expectedReturnValue, evaluationDetails.Value);
     }
@@ -654,7 +654,7 @@ public class ConfigV2EvaluationTests : EvaluationTestsBase
         };
 
         const string defaultValue = "default";
-        var actualReturnValue = evaluator.Evaluate(config!.Settings, key, defaultValue, user, remoteConfig: null, logger).Value;
+        var actualReturnValue = evaluator.Evaluate(config!.SettingsOrEmpty, key, defaultValue, user, remoteConfig: null, logger).Value;
 
         Assert.AreEqual(expectedReturnValue, actualReturnValue);
     }
@@ -718,7 +718,7 @@ public class ConfigV2EvaluationTests : EvaluationTestsBase
         };
 
         const string defaultValue = "default";
-        var actualReturnValue = evaluator.Evaluate(config!.Settings, key, defaultValue, user, remoteConfig: null, logger).Value;
+        var actualReturnValue = evaluator.Evaluate(config!.SettingsOrEmpty, key, defaultValue, user, remoteConfig: null, logger).Value;
 
         Assert.AreEqual(expectedReturnValue, actualReturnValue);
     }
@@ -773,7 +773,7 @@ public class ConfigV2EvaluationTests : EvaluationTestsBase
 
         const string defaultValue = "default";
         string actualReturnValue;
-        try { actualReturnValue = evaluator.Evaluate(config!.Settings, key, defaultValue, user, remoteConfig: null, logger).Value; }
+        try { actualReturnValue = evaluator.Evaluate(config!.SettingsOrEmpty, key, defaultValue, user, remoteConfig: null, logger).Value; }
         catch (InvalidOperationException) { actualReturnValue = defaultValue; }
 
         Assert.AreEqual(expectedReturnValue, actualReturnValue);

--- a/src/ConfigCat.Client.Tests/DataGovernanceTests.cs
+++ b/src/ConfigCat.Client.Tests/DataGovernanceTests.cs
@@ -406,7 +406,7 @@ public class DataGovernanceTests
     {
         var response = new Config
         {
-            Preferences = new Preferences
+            preferences = new Preferences
             {
                 BaseUrl = (url ?? ConfigCatClientOptions.BaseUrlGlobal).ToString(),
                 RedirectMode = redirectMode
@@ -415,7 +415,7 @@ public class DataGovernanceTests
 
         if (withSettings)
         {
-            response.Settings.Add("myKey", "foo".ToSetting());
+            response.SettingsOrEmpty.Add("myKey", "foo".ToSetting());
         }
 
         return response;

--- a/src/ConfigCat.Client.Tests/DataGovernanceTests.cs
+++ b/src/ConfigCat.Client.Tests/DataGovernanceTests.cs
@@ -415,7 +415,7 @@ public class DataGovernanceTests
 
         if (withSettings)
         {
-            response.SettingsOrEmpty.Add("myKey", "foo".ToSetting());
+            response.SettingsOrEmpty.Add("myKey", Setting.FromValue("foo"));
         }
 
         return response;

--- a/src/ConfigCat.Client.Tests/EvaluationLogTests.cs
+++ b/src/ConfigCat.Client.Tests/EvaluationLogTests.cs
@@ -233,7 +233,7 @@ public class EvaluationLogTests
             ? new ConfigLocation.Cdn(sdkKey, baseUrlOrOverrideFileName)
             : new ConfigLocation.LocalFile(TestDataRootPath, "_overrides", baseUrlOrOverrideFileName!);
 
-        var settings = configLocation.FetchConfigCached().Settings;
+        var settings = configLocation.FetchConfigCached().SettingsOrEmpty;
 
         var evaluator = new RolloutEvaluator(logger);
         var evaluationDetails = evaluator.Evaluate(settings, key, defaultValueParsed, user, remoteConfig: null, logger);
@@ -294,7 +294,7 @@ public class EvaluationLogTests
     [DataRow(LogLevel.Debug, true)]
     public void EvaluationLogShouldBeBuiltOnlyWhenNecessary(LogLevel logLevel, bool expectedIsLogBuilt)
     {
-        var settings = new ConfigLocation.Cdn("configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/AG6C1ngVb0CvM07un6JisQ").FetchConfigCached().Settings;
+        var settings = new ConfigLocation.Cdn("configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/AG6C1ngVb0CvM07un6JisQ").FetchConfigCached().SettingsOrEmpty;
 
         var logEvents = new List<LogEvent>();
         var logger = LoggingHelper.CreateCapturingLogger(logEvents, logLevel).AsWrapper();

--- a/src/ConfigCat.Client.Tests/Helpers/ConfigHelper.cs
+++ b/src/ConfigCat.Client.Tests/Helpers/ConfigHelper.cs
@@ -1,14 +1,17 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 
 namespace ConfigCat.Client.Tests.Helpers;
 
 internal static class ConfigHelper
 {
+    public static Dictionary<string, Setting> GetSettings(this Config config) => config.SettingsOrEmpty;
+
     public static ProjectConfig FromString(string configJson, string? httpETag, DateTime timeStamp)
     {
-        return new ProjectConfig(configJson, Config.Deserialize(configJson.AsSpan()), timeStamp, httpETag);
+        return new ProjectConfig(configJson, Config.Deserialize(configJson.AsSpan(), tolerant: false), timeStamp, httpETag);
     }
 
     public static ProjectConfig FromFile(string configJsonFilePath, string? httpETag, DateTime timeStamp)

--- a/src/ConfigCat.Client.Tests/Helpers/ConfigLocation.LocalFile.cs
+++ b/src/ConfigCat.Client.Tests/Helpers/ConfigLocation.LocalFile.cs
@@ -25,7 +25,7 @@ public partial record class ConfigLocation
 #if BENCHMARK_OLD
             return configJson.Deserialize<Config>() ?? throw new InvalidOperationException("Invalid config JSON content: " + configJson);
 #else
-            return Config.Deserialize(configJson.AsSpan());
+            return Config.Deserialize(configJson.AsSpan(), tolerant: false);
 #endif
         }
     }

--- a/src/ConfigCat.Client.Tests/MatrixTestRunnerBase.cs
+++ b/src/ConfigCat.Client.Tests/MatrixTestRunnerBase.cs
@@ -35,7 +35,7 @@ public class MatrixTestRunnerBase<TDescriptor> where TDescriptor : IMatrixTestDe
     public MatrixTestRunnerBase()
     {
         this.isVariationIdMatrixTest = DescriptorInstance is IVariationIdMatrixTest;
-        this.config = DescriptorInstance.ConfigLocation.FetchConfigCached().Settings;
+        this.config = DescriptorInstance.ConfigLocation.FetchConfigCached().GetSettings();
     }
 
     public static IEnumerable<object?[]> GetTests()

--- a/src/ConfigCat.Client.Tests/ModelTests.cs
+++ b/src/ConfigCat.Client.Tests/ModelTests.cs
@@ -43,7 +43,7 @@ public class ModelTests
     [DataRow(FlagDependencyV6SampleSdkKey, null, "boolDependsOnBool", 0, 0, new[] { "Flag 'mainBoolFlag' EQUALS 'True'" })]
     public void Condition_ToString(string? sdkKey, string baseUrlOrFileName, string settingKey, int targetingRuleIndex, int conditionIndex, string[] expectedResultLines)
     {
-        IConfig config = GetConfigLocation(sdkKey, baseUrlOrFileName).FetchConfigCached();
+        Config config = GetConfigLocation(sdkKey, baseUrlOrFileName).FetchConfigCached();
         var setting = config.Settings[settingKey];
         var targetingRule = setting.TargetingRules[targetingRuleIndex];
         var condition = targetingRule.Conditions[conditionIndex];
@@ -57,12 +57,12 @@ public class ModelTests
     [DataRow(ComparatorsV6SampleSdkKey, null, "missingPercentageAttribute", 0, 0, new[] { "50%: 'Falcon'" })]
     public void PercentageOption_ToString(string? sdkKey, string baseUrlOrFileName, string settingKey, int targetingRuleIndex, int percentageOptionIndex, string[] expectedResultLines)
     {
-        IConfig config = GetConfigLocation(sdkKey, baseUrlOrFileName).FetchConfigCached();
+        Config config = GetConfigLocation(sdkKey, baseUrlOrFileName).FetchConfigCached();
         var setting = config.Settings[settingKey];
         var percentageOptions = targetingRuleIndex >= 0
             ? setting.TargetingRules[targetingRuleIndex].PercentageOptions
             : setting.PercentageOptions;
-        IPercentageOption percentageOption = percentageOptions![percentageOptionIndex];
+        PercentageOption percentageOption = percentageOptions![percentageOptionIndex];
         var actualResult = percentageOption!.ToString();
         var expectedResult = string.Join(Environment.NewLine, expectedResultLines);
         Assert.AreEqual(expectedResult, actualResult);
@@ -90,7 +90,7 @@ public class ModelTests
     })]
     public void TargetingRule_ToString(string? sdkKey, string baseUrlOrFileName, string settingKey, int targetingRuleIndex, string[] expectedResultLines)
     {
-        IConfig config = GetConfigLocation(sdkKey, baseUrlOrFileName).FetchConfigCached();
+        Config config = GetConfigLocation(sdkKey, baseUrlOrFileName).FetchConfigCached();
         var setting = config.Settings[settingKey];
         var targetingRule = setting.TargetingRules[targetingRuleIndex];
         var actualResult = targetingRule.ToString();
@@ -155,7 +155,7 @@ public class ModelTests
     })]
     public void Setting_ToString(string? sdkKey, string baseUrlOrFileName, string settingKey, string[] expectedResultLines)
     {
-        IConfig config = GetConfigLocation(sdkKey, baseUrlOrFileName).FetchConfigCached();
+        Config config = GetConfigLocation(sdkKey, baseUrlOrFileName).FetchConfigCached();
         var setting = config.Settings[settingKey];
         var actualResult = setting.ToString();
         var expectedResult = string.Join(Environment.NewLine, expectedResultLines);
@@ -166,7 +166,7 @@ public class ModelTests
     [DataRow(SegmentsV6SampleSdkKey, null, 0, new[] { "User.Email IS ONE OF [<2 hashed values>]" })]
     public void Segment_ToString(string? sdkKey, string baseUrlOrFileName, int segmentIndex, string[] expectedResultLines)
     {
-        IConfig config = GetConfigLocation(sdkKey, baseUrlOrFileName).FetchConfigCached();
+        Config config = GetConfigLocation(sdkKey, baseUrlOrFileName).FetchConfigCached();
         var segment = config.Segments[segmentIndex];
         var actualResult = segment.ToString();
         var expectedResult = string.Join(Environment.NewLine, expectedResultLines);

--- a/src/ConfigCatClient/ConfigCatClient.cs
+++ b/src/ConfigCatClient/ConfigCatClient.cs
@@ -541,7 +541,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         SettingsWithRemoteConfig GetRemoteConfig()
         {
             var config = this.configService.GetInMemoryConfig();
-            var settings = !config.IsEmpty ? config.Config.Settings : null;
+            var settings = !config.IsEmpty ? config.Config.SettingsOrEmpty : null;
             return new SettingsWithRemoteConfig(settings, config);
         }
     }
@@ -573,7 +573,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         async Task<SettingsWithRemoteConfig> GetRemoteConfigAsync(CancellationToken cancellationToken)
         {
             var config = await this.configService.GetConfigAsync(cancellationToken).ConfigureAwait(TaskShim.ContinueOnCapturedContext);
-            var settings = !config.IsEmpty ? config.Config.Settings : null;
+            var settings = !config.IsEmpty ? config.Config.SettingsOrEmpty : null;
             return new SettingsWithRemoteConfig(settings, config);
         }
     }

--- a/src/ConfigCatClient/ConfigCatClient.csproj
+++ b/src/ConfigCatClient/ConfigCatClient.csproj
@@ -54,7 +54,7 @@
         <Reference Include="System.Net.Http" />
         <!--Do not remove this reference, it was added due to a SNYK security report-->
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-        <PackageReference Include="System.Text.Json" Version="6.0.10" />
+        <PackageReference Include="System.Text.Json" Version="8.0.5" />
       </ItemGroup>
     </When>
 
@@ -62,7 +62,7 @@
       <ItemGroup>
         <!--Do not remove this reference, it was added due to a SNYK security report-->
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-        <PackageReference Include="System.Text.Json" Version="6.0.10" />
+        <PackageReference Include="System.Text.Json" Version="8.0.5" />
       </ItemGroup>
     </When>
 
@@ -70,7 +70,13 @@
       <ItemGroup>
         <!--Do not remove this reference, it was added due to a SNYK security report-->
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-        <PackageReference Include="System.Text.Json" Version="6.0.10" />
+        <PackageReference Include="System.Text.Json" Version="8.0.5" />
+      </ItemGroup>
+    </When>
+
+    <When Condition="'$(TargetFramework)' == 'net6.0'">
+      <ItemGroup>
+        <PackageReference Include="System.Text.Json" Version="8.0.5" />
       </ItemGroup>
     </When>
   </Choose>

--- a/src/ConfigCatClient/ConfigCatClientSnapshot.cs
+++ b/src/ConfigCatClient/ConfigCatClientSnapshot.cs
@@ -42,7 +42,7 @@ public readonly struct ConfigCatClientSnapshot : IConfigCatClientSnapshot
         : ((IConfigCatClientSnapshot?)this.evaluationServicesOrFakeImpl)?.CacheState ?? ClientCacheState.NoFlagData;
 
     /// <inheritdoc/>>
-    public IConfig? FetchedConfig => this.evaluationServicesOrFakeImpl is EvaluationServices
+    public Config? FetchedConfig => this.evaluationServicesOrFakeImpl is EvaluationServices
         ? this.settings.RemoteConfig?.Config
         : ((IConfigCatClientSnapshot?)this.evaluationServicesOrFakeImpl)?.FetchedConfig ?? null;
 

--- a/src/ConfigCatClient/ConfigService/DefaultConfigFetcher.cs
+++ b/src/ConfigCatClient/ConfigService/DefaultConfigFetcher.cs
@@ -132,22 +132,22 @@ internal sealed class DefaultConfigFetcher : IConfigFetcher, IDisposable
             }
 
             Config config;
-            try { config = Config.Deserialize(response.Body.AsSpan()); }
+            try { config = Config.Deserialize(response.Body.AsSpan(), tolerant: false); }
             catch (Exception ex) { return new DeserializedResponse(response, ex); }
 
-            if (config.Preferences is null)
+            if (config.preferences is null)
             {
                 return new DeserializedResponse(response, config);
             }
 
             Uri newBaseUri;
 
-            if (config.Preferences.BaseUrl is not { } newBaseUrl || this.baseUri.Equals(newBaseUri = GetBaseUri(newBaseUrl)))
+            if (config.preferences.BaseUrl is not { } newBaseUrl || this.baseUri.Equals(newBaseUri = GetBaseUri(newBaseUrl)))
             {
                 return new DeserializedResponse(response, config);
             }
 
-            RedirectMode redirect = config.Preferences.RedirectMode;
+            RedirectMode redirect = config.preferences.RedirectMode;
 
             if (this.isCustomUri && redirect != RedirectMode.Force)
             {

--- a/src/ConfigCatClient/Evaluation/EvaluateLogHelper.cs
+++ b/src/ConfigCatClient/Evaluation/EvaluateLogHelper.cs
@@ -60,9 +60,9 @@ internal static class EvaluateLogHelper
 
     public static IndentedTextBuilder AppendUserCondition(this IndentedTextBuilder builder, UserCondition condition)
     {
-        var comparisonAttribute = condition.ComparisonAttribute ?? InvalidNamePlaceholder;
+        var comparisonAttribute = condition.comparisonAttribute ?? InvalidNamePlaceholder;
 
-        return condition.Comparator switch
+        return condition.comparator switch
         {
             UserComparator.TextIsOneOf or
             UserComparator.TextIsNotOneOf or
@@ -76,7 +76,7 @@ internal static class EvaluateLogHelper
             UserComparator.TextNotEndsWithAnyOf or
             UserComparator.ArrayContainsAnyOf or
             UserComparator.ArrayNotContainsAnyOf =>
-                builder.AppendUserCondition(comparisonAttribute, condition.Comparator, condition.StringListValue, isSensitive: false),
+                builder.AppendUserCondition(comparisonAttribute, condition.comparator, condition.StringListValue, isSensitive: false),
 
             UserComparator.SemVerLess or
             UserComparator.SemVerLessOrEquals or
@@ -84,7 +84,7 @@ internal static class EvaluateLogHelper
             UserComparator.SemVerGreaterOrEquals or
             UserComparator.TextEquals or
             UserComparator.TextNotEquals =>
-                builder.AppendUserCondition(comparisonAttribute, condition.Comparator, condition.StringValue, isSensitive: false),
+                builder.AppendUserCondition(comparisonAttribute, condition.comparator, condition.StringValue, isSensitive: false),
 
             UserComparator.NumberEquals or
             UserComparator.NumberNotEquals or
@@ -92,7 +92,7 @@ internal static class EvaluateLogHelper
             UserComparator.NumberLessOrEquals or
             UserComparator.NumberGreater or
             UserComparator.NumberGreaterOrEquals =>
-                builder.AppendUserCondition(comparisonAttribute, condition.Comparator, condition.DoubleValue),
+                builder.AppendUserCondition(comparisonAttribute, condition.comparator, condition.DoubleValue),
 
             UserComparator.SensitiveTextIsOneOf or
             UserComparator.SensitiveTextIsNotOneOf or
@@ -102,43 +102,43 @@ internal static class EvaluateLogHelper
             UserComparator.SensitiveTextNotEndsWithAnyOf or
             UserComparator.SensitiveArrayContainsAnyOf or
             UserComparator.SensitiveArrayNotContainsAnyOf =>
-                builder.AppendUserCondition(comparisonAttribute, condition.Comparator, condition.StringListValue, isSensitive: true),
+                builder.AppendUserCondition(comparisonAttribute, condition.comparator, condition.StringListValue, isSensitive: true),
 
             UserComparator.DateTimeBefore or
             UserComparator.DateTimeAfter =>
-                builder.AppendUserCondition(comparisonAttribute, condition.Comparator, condition.DoubleValue, isDateTime: true),
+                builder.AppendUserCondition(comparisonAttribute, condition.comparator, condition.DoubleValue, isDateTime: true),
 
             UserComparator.SensitiveTextEquals or
             UserComparator.SensitiveTextNotEquals =>
-                builder.AppendUserCondition(comparisonAttribute, condition.Comparator, condition.StringValue, isSensitive: true),
+                builder.AppendUserCondition(comparisonAttribute, condition.comparator, condition.StringValue, isSensitive: true),
 
             _ =>
-                builder.AppendUserCondition(comparisonAttribute, condition.Comparator, condition.GetComparisonValue(throwIfInvalid: false)),
+                builder.AppendUserCondition(comparisonAttribute, condition.comparator, condition.GetComparisonValue(throwIfInvalid: false)),
         };
     }
 
     public static IndentedTextBuilder AppendPrerequisiteFlagCondition(this IndentedTextBuilder builder, PrerequisiteFlagCondition condition, IReadOnlyDictionary<string, Setting>? settings = null)
     {
         var prerequisiteFlagKey =
-            condition.PrerequisiteFlagKey is null ? InvalidNamePlaceholder :
-            settings is not null && !settings.ContainsKey(condition.PrerequisiteFlagKey) ? InvalidReferencePlaceholder :
-            condition.PrerequisiteFlagKey;
+            condition.prerequisiteFlagKey is null ? InvalidNamePlaceholder :
+            settings is not null && !settings.ContainsKey(condition.prerequisiteFlagKey) ? InvalidReferencePlaceholder :
+            condition.prerequisiteFlagKey;
 
-        var comparator = condition.Comparator;
-        var comparisonValue = condition.ComparisonValue.GetValue(throwIfInvalid: false);
+        var comparator = condition.comparator;
+        var comparisonValue = condition.comparisonValue.GetValue(throwIfInvalid: false);
 
         return builder.Append($"Flag '{prerequisiteFlagKey}' {comparator.ToDisplayText()} '{comparisonValue ?? InvalidValuePlaceholder}'");
     }
 
     public static IndentedTextBuilder AppendSegmentCondition(this IndentedTextBuilder builder, SegmentCondition condition)
     {
-        var segment = condition.Segment;
-        var comparator = condition.Comparator;
+        var segment = condition.segment;
+        var comparator = condition.comparator;
 
         var segmentName =
             segment is null ? InvalidReferencePlaceholder :
-            segment.Name is not { Length: > 0 } ? InvalidNamePlaceholder :
-            segment.Name;
+            segment.name is not { Length: > 0 } ? InvalidNamePlaceholder :
+            segment.name;
 
         return builder.Append($"User {comparator.ToDisplayText()} '{segmentName}'");
     }
@@ -182,8 +182,8 @@ internal static class EvaluateLogHelper
 
     public static IndentedTextBuilder AppendPercentageOption(this IndentedTextBuilder builder, PercentageOption percentageOptions, string? userAttributeName = null)
     {
-        var percentage = percentageOptions.Percentage;
-        var value = percentageOptions.Value;
+        var percentage = percentageOptions.percentage;
+        var value = percentageOptions.value;
 
         return userAttributeName switch
         {
@@ -215,10 +215,10 @@ internal static class EvaluateLogHelper
         (newLine ? builder.NewLine() : builder.Append(" "))
             .Append("THEN");
 
-        var percentageOptions = targetingRule.PercentageOptions;
+        var percentageOptions = targetingRule.PercentageOptionsOrNull;
         if (percentageOptions is not { Length: > 0 })
         {
-            return builder.Append($" '{targetingRule.SimpleValue?.Value ?? default}'");
+            return builder.Append($" '{targetingRule.SimpleValueOrNull?.value ?? default}'");
         }
         else if (!appendPercentageOptions)
         {
@@ -244,7 +244,7 @@ internal static class EvaluateLogHelper
 
     public static IndentedTextBuilder AppendTargetingRule(this IndentedTextBuilder builder, TargetingRule targetingRule, string? percentageOptionsAttribute = null)
     {
-        var conditions = targetingRule.Conditions;
+        var conditions = targetingRule.ConditionsOrEmpty;
 
         return builder.Append("IF ")
             .AppendConditions(conditions)
@@ -270,10 +270,10 @@ internal static class EvaluateLogHelper
 
     public static IndentedTextBuilder AppendSetting(this IndentedTextBuilder builder, Setting setting)
     {
-        var targetingRules = setting.TargetingRules;
-        var percentageOptions = setting.PercentageOptions;
-        var percentageOptionsAttribute = setting.PercentageOptionsAttribute ?? nameof(User.Identifier);
-        var value = setting.Value;
+        var targetingRules = setting.TargetingRulesOrEmpty;
+        var percentageOptions = setting.PercentageOptionsOrEmpty;
+        var percentageOptionsAttribute = setting.percentageOptionsAttribute ?? nameof(User.Identifier);
+        var value = setting.value;
 
         builder.AppendTargetingRules(targetingRules, percentageOptionsAttribute);
 
@@ -305,7 +305,7 @@ internal static class EvaluateLogHelper
 
     public static IndentedTextBuilder AppendSegment(this IndentedTextBuilder builder, Segment segment)
     {
-        return builder.AppendConditions(segment.Conditions);
+        return builder.AppendConditions(segment.ConditionsOrEmpty);
     }
 
     public static string ToDisplayText(this UserComparator comparator)

--- a/src/ConfigCatClient/Evaluation/EvaluateResult.cs
+++ b/src/ConfigCatClient/Evaluation/EvaluateResult.cs
@@ -10,8 +10,8 @@ internal readonly struct EvaluateResult
     }
 
     private readonly SettingValueContainer selectedValue;
-    public SettingValue Value => this.selectedValue.Value;
-    public string? VariationId => this.selectedValue.VariationId;
+    public SettingValue Value => this.selectedValue.value;
+    public string? VariationId => this.selectedValue.variationId;
 
     public readonly TargetingRule? MatchedTargetingRule;
     public readonly PercentageOption? MatchedPercentageOption;

--- a/src/ConfigCatClient/Evaluation/EvaluationDetails.cs
+++ b/src/ConfigCatClient/Evaluation/EvaluationDetails.cs
@@ -110,12 +110,12 @@ public abstract class EvaluationDetails
     /// <summary>
     /// The targeting rule (if any) that matched during the evaluation and was used to return the evaluated value.
     /// </summary>
-    public ITargetingRule? MatchedTargetingRule { get; set; }
+    public TargetingRule? MatchedTargetingRule { get; set; }
 
     /// <summary>
     /// The percentage option (if any) that was used to select the evaluated value.
     /// </summary>
-    public IPercentageOption? MatchedPercentageOption { get; set; }
+    public PercentageOption? MatchedPercentageOption { get; set; }
 }
 
 /// <inheritdoc/>

--- a/src/ConfigCatClient/Evaluation/EvaluationHelper.cs
+++ b/src/ConfigCatClient/Evaluation/EvaluationHelper.cs
@@ -120,30 +120,30 @@ internal static class EvaluationHelper
             var key = kvp.Key;
             var setting = kvp.Value;
 
-            if (setting.VariationId == variationId)
+            if (setting.variationId == variationId)
             {
-                settingType = setting.SettingType;
-                return new KeyValuePair<string, SettingValue>(key, setting.Value);
+                settingType = setting.settingType;
+                return new KeyValuePair<string, SettingValue>(key, setting.value);
             }
 
-            foreach (var targetingRule in setting.TargetingRules)
+            foreach (var targetingRule in setting.TargetingRulesOrEmpty)
             {
-                if (targetingRule.SimpleValue is { } simpleValue)
+                if (targetingRule.SimpleValueOrNull is { } simpleValue)
                 {
-                    if (simpleValue.VariationId == variationId)
+                    if (simpleValue.variationId == variationId)
                     {
-                        settingType = setting.SettingType;
-                        return new KeyValuePair<string, SettingValue>(key, simpleValue.Value);
+                        settingType = setting.settingType;
+                        return new KeyValuePair<string, SettingValue>(key, simpleValue.value);
                     }
                 }
-                else if (targetingRule.PercentageOptions is { Length: > 0 } percentageOptions)
+                else if (targetingRule.PercentageOptionsOrNull is { Length: > 0 } percentageOptions)
                 {
                     foreach (var percentageOption in percentageOptions)
                     {
-                        if (percentageOption.VariationId == variationId)
+                        if (percentageOption.variationId == variationId)
                         {
-                            settingType = setting.SettingType;
-                            return new KeyValuePair<string, SettingValue>(key, percentageOption.Value);
+                            settingType = setting.settingType;
+                            return new KeyValuePair<string, SettingValue>(key, percentageOption.value);
                         }
                     }
                 }
@@ -153,12 +153,12 @@ internal static class EvaluationHelper
                 }
             }
 
-            foreach (var percentageOption in setting.PercentageOptions)
+            foreach (var percentageOption in setting.PercentageOptionsOrEmpty)
             {
-                if (percentageOption.VariationId == variationId)
+                if (percentageOption.variationId == variationId)
                 {
-                    settingType = setting.SettingType;
-                    return new KeyValuePair<string, SettingValue>(key, percentageOption.Value);
+                    settingType = setting.settingType;
+                    return new KeyValuePair<string, SettingValue>(key, percentageOption.value);
                 }
             }
         }

--- a/src/ConfigCatClient/Extensions/ObjectExtensions.cs
+++ b/src/ConfigCatClient/Extensions/ObjectExtensions.cs
@@ -96,14 +96,14 @@ internal static class ObjectExtensions
     {
         var setting = new Setting
         {
-            Value = value is JsonElement jsonValue
+            value = value is JsonElement jsonValue
                 ? jsonValue.ToSettingValue(out var settingType)
                 : value.ToSettingValue(out settingType),
         };
 
         if (settingType != Setting.UnknownType)
         {
-            setting.SettingType = settingType;
+            setting.settingType = settingType;
         }
 
         return setting;

--- a/src/ConfigCatClient/Hooks/ConfigChangedEventArgs.cs
+++ b/src/ConfigCatClient/Hooks/ConfigChangedEventArgs.cs
@@ -7,13 +7,13 @@ namespace ConfigCat.Client;
 /// </summary>
 public class ConfigChangedEventArgs : EventArgs
 {
-    internal ConfigChangedEventArgs(IConfig newConfig)
+    internal ConfigChangedEventArgs(Config newConfig)
     {
         NewConfig = newConfig;
     }
 
     /// <summary>
-    /// The new <see cref="IConfig"/> object.
+    /// The new <see cref="Config"/> object.
     /// </summary>
-    public IConfig NewConfig { get; }
+    public Config NewConfig { get; }
 }

--- a/src/ConfigCatClient/Hooks/Hooks.cs
+++ b/src/ConfigCatClient/Hooks/Hooks.cs
@@ -42,7 +42,7 @@ internal class Hooks : IProvidesHooks
     public void RaiseConfigFetched(RefreshResult result, bool isInitiatedByUser)
         => this.events.RaiseConfigFetched(this.client, result, isInitiatedByUser);
 
-    public void RaiseConfigChanged(IConfig newConfig)
+    public void RaiseConfigChanged(Config newConfig)
         => this.events.RaiseConfigChanged(this.client, newConfig);
 
     public void RaiseError(ref FormattableLogMessage message, Exception? exception)
@@ -83,7 +83,7 @@ internal class Hooks : IProvidesHooks
         public virtual void RaiseClientReady(IConfigCatClient? client, ClientCacheState cacheState) { /* intentional no-op */ }
         public virtual void RaiseFlagEvaluated(IConfigCatClient? client, EvaluationDetails evaluationDetails) { /* intentional no-op */ }
         public virtual void RaiseConfigFetched(IConfigCatClient? client, RefreshResult result, bool isInitiatedByUser) { /* intentional no-op */ }
-        public virtual void RaiseConfigChanged(IConfigCatClient? client, IConfig newConfig) { /* intentional no-op */ }
+        public virtual void RaiseConfigChanged(IConfigCatClient? client, Config newConfig) { /* intentional no-op */ }
         public virtual void RaiseError(IConfigCatClient? client, ref FormattableLogMessage message, Exception? exception) { /* intentional no-op */ }
 
         public virtual event EventHandler<ClientReadyEventArgs>? ClientReady { add { /* intentional no-op */ } remove { /* intentional no-op */ } }
@@ -110,7 +110,7 @@ internal class Hooks : IProvidesHooks
             ConfigFetched?.Invoke(client, new ConfigFetchedEventArgs(result, isInitiatedByUser));
         }
 
-        public override void RaiseConfigChanged(IConfigCatClient? client, IConfig newConfig)
+        public override void RaiseConfigChanged(IConfigCatClient? client, Config newConfig)
         {
             ConfigChanged?.Invoke(client, new ConfigChangedEventArgs(newConfig));
         }

--- a/src/ConfigCatClient/Hooks/SafeHooksWrapper.cs
+++ b/src/ConfigCatClient/Hooks/SafeHooksWrapper.cs
@@ -33,7 +33,7 @@ internal readonly struct SafeHooksWrapper
         => Hooks.RaiseConfigFetched(result, isInitiatedByUser);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public void RaiseConfigChanged(IConfig newConfig)
+    public void RaiseConfigChanged(Config newConfig)
         => Hooks.RaiseConfigChanged(newConfig);
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/ConfigCatClient/IConfigCatClientSnapshot.cs
+++ b/src/ConfigCatClient/IConfigCatClientSnapshot.cs
@@ -16,7 +16,7 @@ public interface IConfigCatClientSnapshot
     /// <summary>
     /// The internally cached config at the time the snapshot was created.
     /// </summary>
-    IConfig? FetchedConfig { get; }
+    Config? FetchedConfig { get; }
 
     /// <summary>
     /// Returns the available setting keys.

--- a/src/ConfigCatClient/Models/Condition.cs
+++ b/src/ConfigCatClient/Models/Condition.cs
@@ -1,17 +1,17 @@
 namespace ConfigCat.Client;
 
-/// <summary>
-/// Represents a condition.
-/// Can be one of the following types: <see cref="IUserCondition"/>, <see cref="ISegmentCondition"/> or <see cref="IPrerequisiteFlagCondition"/>.
-/// </summary>
-public interface ICondition { }
-
 internal interface IConditionProvider
 {
     Condition? GetCondition(bool throwIfInvalid = true);
 }
 
-internal abstract class Condition : ICondition, IConditionProvider
+/// <summary>
+/// Describes a condition.
+/// Can be one of the following types: <see cref="UserCondition"/>, <see cref="SegmentCondition"/> or <see cref="PrerequisiteFlagCondition"/>.
+/// </summary>
+public abstract class Condition : IConditionProvider
 {
-    public Condition? GetCondition(bool throwIfInvalid = true) => this;
+    private protected Condition() { }
+
+    Condition? IConditionProvider.GetCondition(bool throwIfInvalid) => this;
 }

--- a/src/ConfigCatClient/Models/Config.cs
+++ b/src/ConfigCatClient/Models/Config.cs
@@ -8,13 +8,18 @@ using ConfigCat.Client.Utils;
 namespace ConfigCat.Client;
 
 /// <summary>
-/// Defines the data model of a ConfigCat config.
+/// Describes a ConfigCat config's data model used for feature flag evaluation.
 /// </summary>
 public sealed class Config : IJsonOnDeserialized
 {
     /// <summary>
-    /// Deserializes the specified config JSON to a <see cref="Config"/> data model.
+    /// Deserializes the specified config JSON to a <see cref="Config"/> model that can be used for feature flag evaluation.
     /// </summary>
+    /// <remarks>
+    /// Does superficial model validation only, meaning that the method makes sure that the specified config JSON
+    /// matches the type definition of the <see cref="Config"/> model, but doesn't check for semantic issues. E.g. doesn't validate
+    /// whether referenced segments and feature flags actually exist. (Such issues are checked during feature flag evaluation.)
+    /// </remarks>
     public static Config Deserialize(ReadOnlySpan<char> configJson)
     {
         return Deserialize(configJson, tolerant: true);

--- a/src/ConfigCatClient/Models/PercentageOption.cs
+++ b/src/ConfigCatClient/Models/PercentageOption.cs
@@ -5,21 +5,23 @@ using ConfigCat.Client.Utils;
 namespace ConfigCat.Client;
 
 /// <summary>
-/// Represents a percentage option.
+/// Describes a percentage option.
 /// </summary>
-public interface IPercentageOption : ISettingValueContainer
+public sealed class PercentageOption : SettingValueContainer
 {
+    [JsonConstructor]
+    internal PercentageOption() { }
+
+    [JsonInclude, JsonPropertyName("p")]
+    internal byte percentage;
+
     /// <summary>
     /// A number between 0 and 100 that represents a randomly allocated fraction of the users.
     /// </summary>
-    byte Percentage { get; }
-}
+    [JsonIgnore]
+    public byte Percentage => this.percentage;
 
-internal sealed class PercentageOption : SettingValueContainer, IPercentageOption
-{
-    [JsonPropertyName("p")]
-    public byte Percentage { get; set; }
-
+    /// <inheritdoc />
     public override string ToString()
     {
         return new IndentedTextBuilder()

--- a/src/ConfigCatClient/Models/PrerequisiteFlagCondition.cs
+++ b/src/ConfigCatClient/Models/PrerequisiteFlagCondition.cs
@@ -7,42 +7,42 @@ namespace ConfigCat.Client;
 /// <summary>
 /// Describes a condition that is based on a prerequisite flag.
 /// </summary>
-public interface IPrerequisiteFlagCondition : ICondition
+public sealed class PrerequisiteFlagCondition : Condition
 {
+    internal const PrerequisiteFlagComparator UnknownComparator = (PrerequisiteFlagComparator)byte.MaxValue;
+
+    [JsonConstructor]
+    internal PrerequisiteFlagCondition() { }
+
+    [JsonInclude, JsonPropertyName("f")]
+    internal string? prerequisiteFlagKey;
+
     /// <summary>
     /// The key of the prerequisite flag that the condition is based on.
     /// </summary>
-    string PrerequisiteFlagKey { get; }
+    [JsonIgnore]
+    public string PrerequisiteFlagKey => this.prerequisiteFlagKey ?? throw new InvalidConfigModelException("Prerequisite flag key is missing.");
+
+    [JsonInclude, JsonPropertyName("c")]
+    internal PrerequisiteFlagComparator comparator = UnknownComparator;
 
     /// <summary>
     /// The operator which defines the relation between the evaluated value of the prerequisite flag and the comparison value.
     /// </summary>
-    PrerequisiteFlagComparator Comparator { get; }
+    [JsonIgnore]
+    public PrerequisiteFlagComparator Comparator => this.comparator;
+
+    [JsonInclude, JsonPropertyName("v")]
+    internal SettingValue comparisonValue;
 
     /// <summary>
     /// The value that the evaluated value of the prerequisite flag is compared to.
     /// Can be a value of the following types: <see cref="bool"/>, <see cref="string"/>, <see cref="int"/> or <see cref="double"/>.
     /// </summary>
-    object ComparisonValue { get; }
-}
+    [JsonIgnore]
+    public object ComparisonValue => this.comparisonValue.GetValue()!;
 
-internal sealed class PrerequisiteFlagCondition : Condition, IPrerequisiteFlagCondition
-{
-    public const PrerequisiteFlagComparator UnknownComparator = (PrerequisiteFlagComparator)byte.MaxValue;
-
-    [JsonPropertyName("f")]
-    public string? PrerequisiteFlagKey { get; set; }
-
-    string IPrerequisiteFlagCondition.PrerequisiteFlagKey => PrerequisiteFlagKey ?? throw new InvalidConfigModelException("Prerequisite flag key is missing.");
-
-    [JsonPropertyName("c")]
-    public PrerequisiteFlagComparator Comparator { get; set; } = UnknownComparator;
-
-    [JsonPropertyName("v")]
-    public SettingValue ComparisonValue { get; set; }
-
-    object IPrerequisiteFlagCondition.ComparisonValue => ComparisonValue.GetValue()!;
-
+    /// <inheritdoc />
     public override string ToString()
     {
         return new IndentedTextBuilder()

--- a/src/ConfigCatClient/Models/Setting.cs
+++ b/src/ConfigCatClient/Models/Setting.cs
@@ -12,7 +12,13 @@ namespace ConfigCat.Client;
 /// </summary>
 public sealed class Setting : SettingValueContainer
 {
-    // TODO: Add FromValue method?
+    /// <summary>
+    /// Creates a setting that can be used for feature flag evaluation from the specified value.
+    /// </summary>
+    public static Setting FromValue(object value)
+    {
+        return value.ToSetting();
+    }
 
     internal const SettingType UnknownType = (SettingType)byte.MaxValue;
 

--- a/src/ConfigCatClient/Models/Setting.cs
+++ b/src/ConfigCatClient/Models/Setting.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using ConfigCat.Client.Evaluation;
 using ConfigCat.Client.Utils;
@@ -9,88 +8,78 @@ using ConfigCat.Client.Utils;
 namespace ConfigCat.Client;
 
 /// <summary>
-/// Feature flag or setting.
+/// Describes a feature flag or setting.
 /// </summary>
-public interface ISetting : ISettingValueContainer
+public sealed class Setting : SettingValueContainer
 {
+    // TODO: Add FromValue method?
+
+    internal const SettingType UnknownType = (SettingType)byte.MaxValue;
+
+    [JsonConstructor]
+    internal Setting() { }
+
+    [JsonInclude, JsonPropertyName("t")]
+    internal SettingType settingType = UnknownType;
+
     /// <summary>
     /// Setting type.
     /// </summary>
-    SettingType SettingType { get; }
+    [JsonIgnore]
+    public SettingType SettingType => this.settingType;
+
+    [JsonInclude, JsonPropertyName("a")]
+    internal string? percentageOptionsAttribute;
 
     /// <summary>
     /// The User Object attribute which serves as the basis of percentage options evaluation.
     /// </summary>
-    string PercentageOptionsAttribute { get; }
+    [JsonIgnore]
+    public string PercentageOptionsAttribute => this.percentageOptionsAttribute ?? nameof(User.Identifier);
+
+    [JsonInclude, JsonPropertyName("r")]
+    internal TargetingRule[]? targetingRules;
+
+    internal TargetingRule[] TargetingRulesOrEmpty => this.targetingRules ?? Array.Empty<TargetingRule>();
+
+    private IReadOnlyList<TargetingRule>? targetingRulesReadOnly;
 
     /// <summary>
     /// The list of targeting rules (where there is a logical OR relation between the items).
     /// </summary>
-    IReadOnlyList<ITargetingRule> TargetingRules { get; }
+    [JsonIgnore]
+    public IReadOnlyList<TargetingRule> TargetingRules => this.targetingRulesReadOnly ??= this.targetingRules is { Length: > 0 }
+        ? new ReadOnlyCollection<TargetingRule>(this.targetingRules)
+        : Array.Empty<TargetingRule>();
+
+    [JsonInclude, JsonPropertyName("p")]
+    internal PercentageOption[]? percentageOptions;
+
+    internal PercentageOption[] PercentageOptionsOrEmpty => this.percentageOptions ?? Array.Empty<PercentageOption>();
+
+    private IReadOnlyList<PercentageOption>? percentageOptionsReadOnly;
 
     /// <summary>
     /// The list of percentage options.
     /// </summary>
-    IReadOnlyList<IPercentageOption> PercentageOptions { get; }
-}
-
-internal sealed class Setting : SettingValueContainer, ISetting
-{
-    public const SettingType UnknownType = (SettingType)byte.MaxValue;
-
-    [JsonPropertyName("t")]
-    public SettingType SettingType { get; set; } = UnknownType;
-
-    [JsonPropertyName("a")]
-    [NotNull]
-    public string? PercentageOptionsAttribute { get; set; }
-
-    string ISetting.PercentageOptionsAttribute => PercentageOptionsAttribute ?? nameof(User.Identifier);
-
-    private TargetingRule[]? targetingRules;
-
-    [JsonPropertyName("r")]
-    [NotNull]
-    public TargetingRule[]? TargetingRules
-    {
-        get => this.targetingRules ?? Array.Empty<TargetingRule>();
-        set => this.targetingRules = value;
-    }
-
-    private IReadOnlyList<ITargetingRule>? targetingRulesReadOnly;
-
-    IReadOnlyList<ITargetingRule> ISetting.TargetingRules => this.targetingRulesReadOnly ??= this.targetingRules is { Length: > 0 }
-        ? new ReadOnlyCollection<ITargetingRule>(this.targetingRules)
-        : Array.Empty<ITargetingRule>();
-
-    private PercentageOption[]? percentageOptions;
-
-    [JsonPropertyName("p")]
-    [NotNull]
-    public PercentageOption[]? PercentageOptions
-    {
-        get => this.percentageOptions ?? Array.Empty<PercentageOption>();
-        set => this.percentageOptions = value;
-    }
-
-    private IReadOnlyList<IPercentageOption>? percentageOptionsReadOnly;
-    IReadOnlyList<IPercentageOption> ISetting.PercentageOptions => this.percentageOptionsReadOnly ??= this.percentageOptions is { Length: > 0 }
-        ? new ReadOnlyCollection<IPercentageOption>(this.percentageOptions)
-        : Array.Empty<IPercentageOption>();
-
     [JsonIgnore]
-    public string? ConfigJsonSalt { get; private set; }
+    public IReadOnlyList<PercentageOption> PercentageOptions => this.percentageOptionsReadOnly ??= this.percentageOptions is { Length: > 0 }
+        ? new ReadOnlyCollection<PercentageOption>(this.percentageOptions)
+        : Array.Empty<PercentageOption>();
+
+    internal string? configJsonSalt;
 
     internal void OnConfigDeserialized(Config config)
     {
-        ConfigJsonSalt = config.Preferences?.Salt;
+        this.configJsonSalt = config.preferences?.Salt;
 
-        foreach (var targetingRule in TargetingRules)
+        foreach (var targetingRule in TargetingRulesOrEmpty)
         {
             targetingRule.OnConfigDeserialized(config);
         }
     }
 
+    /// <inheritdoc />
     public override string ToString()
     {
         return new IndentedTextBuilder()

--- a/src/ConfigCatClient/Models/Setting.cs
+++ b/src/ConfigCatClient/Models/Setting.cs
@@ -31,6 +31,9 @@ public sealed class Setting : SettingValueContainer
     /// <summary>
     /// Setting type.
     /// </summary>
+    /// <remarks>
+    /// Can also be <see cref="byte.MaxValue"/> when the setting comes from a simple flag override with an unsupported value.
+    /// </remarks>
     [JsonIgnore]
     public SettingType SettingType => this.settingType;
 

--- a/src/ConfigCatClient/Models/SettingValueContainer.cs
+++ b/src/ConfigCatClient/Models/SettingValueContainer.cs
@@ -5,32 +5,31 @@ namespace ConfigCat.Client;
 /// <summary>
 /// A model object which contains a setting value along with related data.
 /// </summary>
-public interface ISettingValueContainer
+public abstract class SettingValueContainer
 {
+    private protected SettingValueContainer() { }
+
+    [JsonInclude, JsonPropertyName("v")]
+    internal SettingValue value;
+
     /// <summary>
     /// Setting value.
     /// Can be a value of the following types: <see cref="bool"/>, <see cref="string"/>, <see cref="int"/> or <see cref="double"/>.
     /// </summary>
-    object Value { get; }
+    [JsonIgnore]
+    public object Value => this.value.GetValue()!;
+
+    [JsonInclude, JsonPropertyName("i")]
+    internal string? variationId;
 
     /// <summary>
     /// Variation ID.
     /// </summary>
-    string? VariationId { get; }
+    [JsonIgnore]
+    public string? VariationId => this.variationId;
 }
 
-internal abstract class SettingValueContainer : ISettingValueContainer
-{
-    [JsonPropertyName("v")]
-    public SettingValue Value { get; set; }
-
-    object ISettingValueContainer.Value => Value.GetValue()!;
-
-    [JsonPropertyName("i")]
-    public string? VariationId { get; set; }
-}
-
-// NOTE: This sealed class is for fast type checking in TargetingRule.SimpleValue
+// NOTE: This sealed class is for fast type checking in TargetingRule.SimpleValueOrNull
 // (see also https://stackoverflow.com/a/70065177/8656352).
 internal sealed class SimpleSettingValue : SettingValueContainer
 {

--- a/src/ConfigCatClient/Override/LocalDictionaryDataSource.cs
+++ b/src/ConfigCatClient/Override/LocalDictionaryDataSource.cs
@@ -13,7 +13,7 @@ internal sealed class LocalDictionaryDataSource : IOverrideDataSource
 
     public LocalDictionaryDataSource(IDictionary<string, object> overrideValues, bool watchChanges)
     {
-        this.initialSettings = overrideValues.ToDictionary(kv => kv.Key, kv => kv.Value.ToSetting());
+        this.initialSettings = overrideValues.ToDictionary(kv => kv.Key, kv => Setting.FromValue(kv.Value));
         if (watchChanges)
         {
             this.overrideValues = overrideValues;
@@ -25,6 +25,6 @@ internal sealed class LocalDictionaryDataSource : IOverrideDataSource
     public Task<Dictionary<string, Setting>> GetOverridesAsync(CancellationToken cancellationToken = default) => Task.FromResult(GetSettingsFromSource());
 
     private Dictionary<string, Setting> GetSettingsFromSource() => this.overrideValues is not null
-        ? this.overrideValues.ToDictionary(kv => kv.Key, kv => kv.Value.ToSetting())
+        ? this.overrideValues.ToDictionary(kv => kv.Key, kv => Setting.FromValue(kv.Value))
         : this.initialSettings;
 }

--- a/src/ConfigCatClient/Override/LocalFileDataSource.cs
+++ b/src/ConfigCatClient/Override/LocalFileDataSource.cs
@@ -118,7 +118,7 @@ internal sealed class LocalFileDataSource : IOverrideDataSource, IDisposable
                     }
 
                     var deserialized = Config.Deserialize(content.AsSpan(), tolerant: true);
-                    this.overrideValues = deserialized.Settings;
+                    this.overrideValues = deserialized.SettingsOrEmpty;
                     break;
                 }
                 // this logic ensures that we keep trying to open the file for max 10s

--- a/src/ConfigCatClient/Override/LocalFileDataSource.cs
+++ b/src/ConfigCatClient/Override/LocalFileDataSource.cs
@@ -113,7 +113,7 @@ internal sealed class LocalFileDataSource : IOverrideDataSource, IDisposable
                     var simplified = SerializationHelper.DeserializeSimplifiedConfig(content.AsSpan(), tolerant: true, throwOnError: false);
                     if (simplified?.Entries is not null)
                     {
-                        this.overrideValues = simplified.Entries.ToDictionary(kv => kv.Key, kv => kv.Value.ToSetting());
+                        this.overrideValues = simplified.Entries.ToDictionary(kv => kv.Key, kv => Setting.FromValue(kv.Value));
                         break;
                     }
 

--- a/src/ConfigCatClient/ProjectConfig.cs
+++ b/src/ConfigCatClient/ProjectConfig.cs
@@ -95,7 +95,7 @@ internal sealed class ProjectConfig
         string? configJson;
         if (configJsonSpan.Length > 0)
         {
-            config = Config.Deserialize(configJsonSpan);
+            config = Config.Deserialize(configJsonSpan, tolerant: false);
             configJson = configJsonSpan.ToString();
         }
         else


### PR DESCRIPTION
### Describe the purpose of your pull request
Removes the config model interfaces and publishes the classes that were hidden behind them instead. (The public API of model classes will be the same as the API that the removed interfaces defined, so this should be a tolerable breaking change.)

This is also a prerequisite for https://trello.com/c/Wc4qxVkE and further potential improvements.

Note: to keep the model classes immutable for consumers, we need to deserialize data into internal fields/properties. This was not possible with source generation before System.Text.Json v8.x, so this dependency had to be updated. (Which is only possible after dropping support for .NET 4.6.1 and older.)

### Related issues (only if applicable)
n/a

### How to test? (only if applicable)
n/a

### Security (only if applicable)
n/a

### Requirement checklist (only if applicable)
- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
