### PR TITLE
Fix NRE bug when accessing client instance during client initialization

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  build_version: 9.4.2
+  build_version: 9.4.3
 version: $(build_version)-{build}
 image: Visual Studio 2022
 configuration: Release

--- a/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
+++ b/src/ConfigCat.Client.Tests/ConfigCatClientTests.cs
@@ -2357,6 +2357,54 @@ public class ConfigCatClientTests
         Assert.AreEqual(2, errorEvents.Count);
     }
 
+    [DataRow(nameof(AutoPoll), ClientCacheState.HasUpToDateFlagData)]
+    [DataRow(nameof(LazyLoad), ClientCacheState.HasUpToDateFlagData)]
+    [DataRow(nameof(ManualPoll), ClientCacheState.HasCachedFlagDataOnly)]
+    [DataRow(null, ClientCacheState.HasLocalOverrideFlagDataOnly)]
+    [DataTestMethod]
+    public void Hooks_ClientShouldAlreadyBeUsableWhenEventIsEmittedDuringInitialization(string? pollingMode, ClientCacheState expectedCacheState)
+    {
+        var fakeCache = new FakeExternalCache();
+        const string configJson = "{\"f\":{\"debug\":{\"t\":0,\"v\":{\"b\":true}}}}";
+        fakeCache.CachedValue = ProjectConfig.Serialize(new ProjectConfig(configJson, Config.Deserialize(configJson.AsMemory()), ProjectConfig.GenerateTimeStamp(), "etag"));
+
+        var configFetcherMock = new Mock<IConfigCatConfigFetcher>();
+        configFetcherMock
+            .Setup(m => m.FetchAsync(It.IsAny<FetchRequest>(), It.IsAny<CancellationToken>()))
+            .Callback((FetchRequest _, CancellationToken ct) => Task.Delay(Timeout.Infinite, ct));
+
+        IConfigCatClientSnapshot? snapshot = null;
+
+        var options = pollingMode switch
+        {
+            nameof(AutoPoll) => new ConfigCatClientOptions { PollingMode = PollingModes.AutoPoll() },
+            nameof(LazyLoad) => new ConfigCatClientOptions { PollingMode = PollingModes.LazyLoad() },
+            nameof(ManualPoll) => new ConfigCatClientOptions { PollingMode = PollingModes.ManualPoll },
+            null => new ConfigCatClientOptions { FlagOverrides = FlagOverrides.LocalDictionary(new Dictionary<string, object> { ["debug"] = true }, OverrideBehaviour.LocalOnly) },
+            _ => throw new ArgumentOutOfRangeException(nameof(pollingMode), pollingMode, null)
+        };
+
+        options.ConfigCache = fakeCache;
+        options.ConfigFetcher = configFetcherMock.Object;
+        if (pollingMode is not null)
+        {
+            options.ConfigChanged += (s, e) => snapshot = ((IConfigCatClient)s!).Snapshot();
+        }
+        else
+        {
+            options.ClientReady += (s, e) => snapshot = ((IConfigCatClient)s!).Snapshot();
+        }
+
+        Assert.IsNull(snapshot);
+
+        using var client = new ConfigCatClient("SDK-KEY", options);
+
+        Assert.IsNotNull(snapshot);
+        Assert.AreEqual(expectedCacheState, snapshot.CacheState);
+        Assert.AreEqual(pollingMode is not null, snapshot.FetchedConfig is not null);
+        Assert.IsTrue(snapshot.GetValue("debug", (bool?)null));
+    }
+
     [TestMethod]
     public async Task LogFilter_Works()
     {

--- a/src/ConfigCatClient/ConfigCatClient.cs
+++ b/src/ConfigCatClient/ConfigCatClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -38,7 +39,7 @@ public sealed class ConfigCatClient : IConfigCatClient
 
     private readonly string? sdkKey; // may be null in case of testing
     private readonly EvaluationServices evaluationServices;
-    private readonly IConfigService configService;
+    private IConfigService configService;
     private readonly IOverrideDataSource? overrideDataSource;
     private readonly OverrideBehaviour? overrideBehaviour;
     private readonly Hooks hooks;
@@ -97,7 +98,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         this.sdkKey = sdkKey;
 
         this.hooks = options.YieldHooks();
-        this.hooks.SetSender(this);
+        this.hooks.Sender = this;
 
         // To avoid possible memory leaks, the components of the client or client snapshots should not
         // hold a strong reference to the hooks object (see also SafeHooksWrapper).
@@ -126,8 +127,11 @@ public sealed class ConfigCatClient : IConfigCatClient
 
         var pollingMode = options.PollingMode ?? ConfigCatClientOptions.CreateDefaultPollingMode();
 
-        this.configService = this.overrideBehaviour != OverrideBehaviour.LocalOnly
-            ? DetermineConfigService(pollingMode,
+        // At this point the client instance must be fully initialized (apart from the configService field) because it
+        // may be accessed from a handler of an event that is raised during the initialization of the config service.
+        // (At the same time, the config service must initialize the configService field before raising any events.)
+        var configService = this.overrideBehaviour != OverrideBehaviour.LocalOnly
+            ? pollingMode.CreateConfigService(
                 new DefaultConfigFetcher(sdkKey,
                     options.GetBaseUri(),
                     GetProductVersion(pollingMode),
@@ -142,6 +146,16 @@ public sealed class ConfigCatClient : IConfigCatClient
                 options.Offline,
                 hooksWrapper)
             : new NullConfigService(logger, hooksWrapper);
+
+        Debug.Assert(ReferenceEquals(this.configService, configService) || this.hooks.Sender is null, $"The {nameof(this.configService)} field was not initialized.");
+
+        this.configService = configService;
+    }
+
+    internal void InitializeConfigService(IConfigService instance)
+    {
+        Debug.Assert(this.configService is null, $"The {nameof(this.configService)} field was already initialized.");
+        this.configService = instance;
     }
 
     // For test purposes only
@@ -154,7 +168,7 @@ public sealed class ConfigCatClient : IConfigCatClient
 #endif
 
         this.hooks = hooks ?? NullHooks.Instance;
-        this.hooks.SetSender(this);
+        this.hooks.Sender = this;
         var hooksWrapper = new SafeHooksWrapper(this.hooks);
 
         this.evaluationServices = new EvaluationServices(evaluator, hooksWrapper, new LoggerWrapper(logger, logFilter, hooks));
@@ -782,31 +796,6 @@ public sealed class ConfigCatClient : IConfigCatClient
             var settings = !config.IsEmpty ? config.Config.Settings : null;
             return new SettingsWithRemoteConfig(settings, config);
         }
-    }
-
-    private static IConfigService DetermineConfigService(PollingMode pollingMode, IConfigFetcher fetcher, CacheParameters cacheParameters, LoggerWrapper logger, bool isOffline, SafeHooksWrapper hooks)
-    {
-        return pollingMode switch
-        {
-            AutoPoll autoPoll => new AutoPollConfigService(autoPoll,
-                fetcher,
-                cacheParameters,
-                logger,
-                isOffline,
-                hooks),
-            LazyLoad lazyLoad => new LazyLoadConfigService(fetcher,
-                cacheParameters,
-                logger,
-                lazyLoad.CacheTimeToLive,
-                isOffline,
-                hooks),
-            ManualPoll => new ManualPollConfigService(fetcher,
-                cacheParameters,
-                logger,
-                isOffline,
-                hooks),
-            _ => throw new ArgumentException("Invalid polling mode.", nameof(pollingMode)),
-        };
     }
 
     /// <inheritdoc />

--- a/src/ConfigCatClient/ConfigService/AutoPollConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/AutoPollConfigService.cs
@@ -44,6 +44,8 @@ internal sealed class AutoPollConfigService : ConfigServiceBase, IConfigService
 
         this.maxInitWaitTime = options.MaxInitWaitTime >= TimeSpan.Zero ? options.MaxInitWaitTime : Timeout.InfiniteTimeSpan;
 
+        PrepareClientForEvents(this, hooks);
+
         var initialCacheSyncUpTask = SyncUpWithCacheAsync().AsTask();
 
         // This task will complete as soon as

--- a/src/ConfigCatClient/ConfigService/ConfigServiceBase.cs
+++ b/src/ConfigCatClient/ConfigService/ConfigServiceBase.cs
@@ -15,6 +15,11 @@ namespace ConfigCat.Client.ConfigService;
 
 internal abstract class ConfigServiceBase : IDisposable
 {
+    public static void PrepareClientForEvents(IConfigService instance, SafeHooksWrapper hooks)
+    {
+        (hooks.Hooks.Sender as ConfigCatClient)?.InitializeConfigService(instance);
+    }
+
     protected internal enum Status
     {
         Online,

--- a/src/ConfigCatClient/ConfigService/LazyLoadConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/LazyLoadConfigService.cs
@@ -15,6 +15,8 @@ internal sealed class LazyLoadConfigService : ConfigServiceBase, IConfigService
     {
         this.cacheTimeToLive = cacheTimeToLive;
 
+        PrepareClientForEvents(this, hooks);
+
         var initialCacheSyncUpTask = SyncUpWithCacheAsync().AsTask();
         ReadyTask = GetReadyTask(initialCacheSyncUpTask);
     }

--- a/src/ConfigCatClient/ConfigService/ManualPollConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/ManualPollConfigService.cs
@@ -10,6 +10,8 @@ internal sealed class ManualPollConfigService : ConfigServiceBase, IConfigServic
     internal ManualPollConfigService(IConfigFetcher configFetcher, CacheParameters cacheParameters, LoggerWrapper logger, bool isOffline = false, SafeHooksWrapper hooks = default)
         : base(configFetcher, cacheParameters, logger, isOffline, hooks)
     {
+        PrepareClientForEvents(this, hooks);
+
         var initialCacheSyncUpTask = SyncUpWithCacheAsync().AsTask();
         ReadyTask = GetReadyTask(initialCacheSyncUpTask);
     }

--- a/src/ConfigCatClient/ConfigService/NullConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/NullConfigService.cs
@@ -11,6 +11,8 @@ internal sealed class NullConfigService : IConfigService
     {
         this.logger = logger;
 
+        ConfigServiceBase.PrepareClientForEvents(this, hooks);
+
         hooks.RaiseClientReady(ClientCacheState.HasLocalOverrideFlagDataOnly);
     }
 

--- a/src/ConfigCatClient/Hooks/Hooks.cs
+++ b/src/ConfigCatClient/Hooks/Hooks.cs
@@ -28,9 +28,10 @@ internal class Hooks : IProvidesHooks
         return !ReferenceEquals(originalEvents, DisconnectedEvents);
     }
 
-    public virtual void SetSender(IConfigCatClient client)
+    public virtual IConfigCatClient? Sender
     {
-        this.client = client;
+        get => this.client;
+        set => this.client = value;
     }
 
     public void RaiseClientReady(ClientCacheState cacheState)

--- a/src/ConfigCatClient/Hooks/NullHooks.cs
+++ b/src/ConfigCatClient/Hooks/NullHooks.cs
@@ -11,5 +11,9 @@ internal sealed class NullHooks : Hooks
         return false;
     }
 
-    public override void SetSender(IConfigCatClient client) { /* this is an intentional no-op */ }
+    public override IConfigCatClient? Sender
+    {
+        get => null;
+        set { /* this is an intentional no-op */  }
+    }
 }

--- a/src/ConfigCatClient/Hooks/SafeHooksWrapper.cs
+++ b/src/ConfigCatClient/Hooks/SafeHooksWrapper.cs
@@ -13,7 +13,7 @@ internal readonly struct SafeHooksWrapper
 {
     private readonly WeakReference<Hooks> hooksWeakRef;
 
-    private Hooks Hooks => this.hooksWeakRef is { } hooksWeakRef && hooksWeakRef.TryGetTarget(out var hooks) ? hooks! : NullHooks.Instance;
+    public Hooks Hooks => this.hooksWeakRef is { } hooksWeakRef && hooksWeakRef.TryGetTarget(out var hooks) ? hooks! : NullHooks.Instance;
 
     public SafeHooksWrapper(Hooks hooks)
     {

--- a/src/ConfigCatClient/Logging/LogMessages.cs
+++ b/src/ConfigCatClient/Logging/LogMessages.cs
@@ -33,7 +33,7 @@ internal static partial class LoggerExtensions
         $"Error occurred in the `{methodName}` method while evaluating setting '{key}'. Returning the `{defaultParamName}` parameter that you specified in your application: '{defaultParamValue}'.",
         "METHOD_NAME", "KEY", "DEFAULT_PARAM_NAME", "DEFAULT_PARAM_VALUE");
 
-    public static FormattableLogMessage ForceRefreshError(this LoggerWrapper logger, string methodName, Exception ex) => logger.LogInterpolated(
+    public static FormattableLogMessage ClientMethodError(this LoggerWrapper logger, string methodName, Exception ex) => logger.LogInterpolated(
         LogLevel.Error, 1003, ex,
         $"Error occurred in the `{methodName}` method.",
         "METHOD_NAME");


### PR DESCRIPTION
### Describe the purpose of your pull request

The SDK has a long-standing bug that occurs when the client instance is used in a hook event handler during client initialization. For example, a setup like

```cs
ConfigCatClient.Get("SDK-KEY", options =>
{
    options.ConfigChanged += (s, e) => snapshot = ((IConfigCatClient)s!).GetValue(...);
});      
```

blows up when up-to-date config data is already available in the cache because in that case the event is raised before all fields are initialized in `ConfigCatClient` . A call like `GetValue` accesses those fields, resulting in a `NullReferenceException` exception.

This PR fixes this issue.

### Related issues (only if applicable)
n/a

### How to test? (only if applicable)
n/a

### Security (only if applicable)
n/a

### Requirement checklist (only if applicable)
- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
