### PR TITLE
Refactor `GetMonotonicTime` to use `Environment.TickCount64`

### DIFF
--- a/src/ConfigCatClient/Utils/DateTimeUtils.cs
+++ b/src/ConfigCatClient/Utils/DateTimeUtils.cs
@@ -84,6 +84,6 @@ internal static class DateTimeUtils
 
     public static TimeSpan GetMonotonicTime()
     {
-        return TimeSpan.FromSeconds(Stopwatch.GetTimestamp() / (double)Stopwatch.Frequency);
+        return TimeSpan.FromMilliseconds(Environment.TickCount64);
     }
 }

--- a/src/ConfigCatClient/Utils/DateTimeUtils.cs
+++ b/src/ConfigCatClient/Utils/DateTimeUtils.cs
@@ -84,6 +84,10 @@ internal static class DateTimeUtils
 
     public static TimeSpan GetMonotonicTime()
     {
+#if NET
         return TimeSpan.FromMilliseconds(Environment.TickCount64);
+#else
+        return TimeSpan.FromSeconds(Stopwatch.GetTimestamp() / (double)Stopwatch.Frequency);
+#endif
     }
 }


### PR DESCRIPTION
- I have covered the applied changes with automated tests.
- I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
