### PR TITLE
Exclude .NET 3.1 on Windows in CI workflow

### DIFF
--- a/.github/workflows/dotnet-sdk-ci.yml
+++ b/.github/workflows/dotnet-sdk-ci.yml
@@ -52,6 +52,8 @@ jobs:
           - dotnet-version: {rt: "3.1.x", sdk: "3.1.100", tfm: netcoreapp3.1}
             os: ubuntu-latest
           - dotnet-version: {rt: "3.1.x", sdk: "3.1.100", tfm: netcoreapp3.1}
+            os: windows-latest
+          - dotnet-version: {rt: "3.1.x", sdk: "3.1.100", tfm: netcoreapp3.1}
             os: macOS-latest
     name: Build & test on .NET ${{ matrix.dotnet-version.rt }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
> ```
> You must install or update .NET to run this application.
> App: C:\Users\appveyor\.dotnet\tools\InheritDoc.exe
> Architecture: x64
> Framework: 'Microsoft.NETCore.App', version '3.1.0' (x64)
> .NET location: C:\Program Files\dotnet\
> The following frameworks were found:
> ```
> 
> .NET Core 3.1 is long end-of-life. It appears the runtime is not present on the build machine.
