### PR TITLE
Allow custom flag override data sources

### DIFF
--- a/src/ConfigCatClient/ConfigCatClientSnapshot.cs
+++ b/src/ConfigCatClient/ConfigCatClientSnapshot.cs
@@ -56,7 +56,7 @@ public readonly struct ConfigCatClientSnapshot : IConfigCatClientSnapshot
                 : Array.Empty<string>();
         }
 
-        return this.settings.Value is { } settings ? settings.Keys : Array.Empty<string>();
+        return this.settings.Value is { } settings ? settings.KeyCollection() : Array.Empty<string>();
     }
 
     /// <inheritdoc/>>

--- a/src/ConfigCatClient/Evaluation/EvaluationHelper.cs
+++ b/src/ConfigCatClient/Evaluation/EvaluationHelper.cs
@@ -8,7 +8,7 @@ namespace ConfigCat.Client.Evaluation;
 
 internal static class EvaluationHelper
 {
-    public static EvaluationDetails<T> Evaluate<T>(this IRolloutEvaluator evaluator, Dictionary<string, Setting>? settings, string key, T defaultValue, User? user,
+    public static EvaluationDetails<T> Evaluate<T>(this IRolloutEvaluator evaluator, IReadOnlyDictionary<string, Setting>? settings, string key, T defaultValue, User? user,
         ProjectConfig? remoteConfig, LoggerWrapper logger)
     {
         FormattableLogMessage logMessage;
@@ -22,7 +22,7 @@ internal static class EvaluationHelper
 
         if (!settings.TryGetValue(key, out var setting))
         {
-            var availableKeys = new StringListFormatter(settings.Keys);
+            var availableKeys = new StringListFormatter(settings.KeyCollection());
             logMessage = logger.SettingEvaluationFailedDueToMissingKey(key, nameof(defaultValue), defaultValue, availableKeys);
             return EvaluationDetails.FromDefaultValue(key, defaultValue, fetchTime: remoteConfig?.TimeStamp, user,
                 logMessage.ToLazyString(), errorCode: EvaluationErrorCode.SettingKeyMissing);
@@ -37,7 +37,7 @@ internal static class EvaluationHelper
         return EvaluationDetails.FromEvaluateResult(key, value, evaluateResult, fetchTime: remoteConfig?.TimeStamp, user);
     }
 
-    public static EvaluationDetails[] EvaluateAll(this IRolloutEvaluator evaluator, Dictionary<string, Setting>? settings, User? user,
+    public static EvaluationDetails[] EvaluateAll(this IRolloutEvaluator evaluator, IReadOnlyDictionary<string, Setting>? settings, User? user,
         ProjectConfig? remoteConfig, LoggerWrapper logger, string defaultReturnValue, out IReadOnlyList<Exception>? exceptions)
     {
         if (!CheckSettingsAvailable(settings, logger, defaultReturnValue))
@@ -79,7 +79,7 @@ internal static class EvaluationHelper
         return evaluationDetailsArray;
     }
 
-    internal static KeyValuePair<string, T>? GetKeyAndValue<T>(Dictionary<string, Setting>? settings, string variationId, LoggerWrapper logger, string defaultReturnValue)
+    internal static KeyValuePair<string, T>? GetKeyAndValue<T>(IReadOnlyDictionary<string, Setting>? settings, string variationId, LoggerWrapper logger, string defaultReturnValue)
     {
         if (!CheckSettingsAvailable(settings, logger, defaultReturnValue))
         {
@@ -113,7 +113,7 @@ internal static class EvaluationHelper
         return null;
     }
 
-    private static KeyValuePair<string, SettingValue>? FindKeyAndValue(Dictionary<string, Setting> settings, string variationId, out SettingType settingType)
+    private static KeyValuePair<string, SettingValue>? FindKeyAndValue(IReadOnlyDictionary<string, Setting> settings, string variationId, out SettingType settingType)
     {
         foreach (var kvp in settings)
         {
@@ -167,7 +167,7 @@ internal static class EvaluationHelper
         return null;
     }
 
-    internal static bool CheckSettingsAvailable([NotNullWhen(true)] Dictionary<string, Setting>? settings, LoggerWrapper logger, string defaultReturnValue)
+    internal static bool CheckSettingsAvailable([NotNullWhen(true)] IReadOnlyDictionary<string, Setting>? settings, LoggerWrapper logger, string defaultReturnValue)
     {
         if (settings is null)
         {

--- a/src/ConfigCatClient/Extensions/DictionaryExtensions.cs
+++ b/src/ConfigCatClient/Extensions/DictionaryExtensions.cs
@@ -1,8 +1,21 @@
+using System.Linq;
+
 namespace System.Collections.Generic;
 
 internal static class DictionaryExtensions
 {
-    public static Dictionary<TKey, TValue> MergeOverwriteWith<TKey, TValue>(this Dictionary<TKey, TValue>? source, Dictionary<TKey, TValue>? other)
+    public static IReadOnlyCollection<TKey> KeyCollection<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> source)
+        where TKey : notnull
+    {
+        return
+            // NOTE: It's worth special-casing Dictionary<TKey, TValue> for performance since it will almost always be
+            // the underlying type in our use cases.
+            source is Dictionary<TKey, TValue> dictionary ? dictionary.Keys
+            : source.Keys is IReadOnlyCollection<TKey> keyCollection ? keyCollection
+            : source.Keys.ToArray();
+    }
+
+    public static Dictionary<TKey, TValue> MergeOverwriteWith<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue>? source, IReadOnlyDictionary<TKey, TValue>? other)
         where TKey : notnull
     {
         Dictionary<TKey, TValue> result;

--- a/src/ConfigCatClient/Override/IOverrideDataSource.cs
+++ b/src/ConfigCatClient/Override/IOverrideDataSource.cs
@@ -1,12 +1,18 @@
 using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace ConfigCat.Client.Override;
 
-internal interface IOverrideDataSource
+/// <summary>
+/// Defines the interface used by the ConfigCat SDK to obtain flag overrides.
+/// </summary>
+public interface IOverrideDataSource
 {
-    Dictionary<string, Setting> GetOverrides();
-
-    Task<Dictionary<string, Setting>> GetOverridesAsync(CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Returns the flag overrides as a <see cref="Dictionary{TKey, TValue}"/> where the dictionary key is the feature flag key.
+    /// </summary>
+    /// <remarks>
+    /// Note for implementers. Mutating the returned dictionary results in undefined behavior, thus, it must be avoided.
+    /// </remarks>
+    /// <returns>The dictionary of flag overrides.</returns>
+    IReadOnlyDictionary<string, Setting> GetOverrides();
 }

--- a/src/ConfigCatClient/Override/LocalDictionaryDataSource.cs
+++ b/src/ConfigCatClient/Override/LocalDictionaryDataSource.cs
@@ -1,8 +1,5 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace ConfigCat.Client.Override;
 
@@ -20,11 +17,7 @@ internal sealed class LocalDictionaryDataSource : IOverrideDataSource
         }
     }
 
-    public Dictionary<string, Setting> GetOverrides() => GetSettingsFromSource();
-
-    public Task<Dictionary<string, Setting>> GetOverridesAsync(CancellationToken cancellationToken = default) => Task.FromResult(GetSettingsFromSource());
-
-    private Dictionary<string, Setting> GetSettingsFromSource() => this.overrideValues is not null
+    public IReadOnlyDictionary<string, Setting> GetOverrides() => this.overrideValues is not null
         ? this.overrideValues.ToDictionary(kv => kv.Key, kv => Setting.FromValue(kv.Value))
         : this.initialSettings;
 }

--- a/src/ConfigCatClient/Override/LocalFileDataSource.cs
+++ b/src/ConfigCatClient/Override/LocalFileDataSource.cs
@@ -49,9 +49,7 @@ internal sealed class LocalFileDataSource : IOverrideDataSource, IDisposable
         }
     }
 
-    public Dictionary<string, Setting> GetOverrides() => this.overrideValues ?? new Dictionary<string, Setting>();
-
-    public Task<Dictionary<string, Setting>> GetOverridesAsync(CancellationToken cancellationToken = default) => Task.FromResult(this.overrideValues ?? new Dictionary<string, Setting>());
+    public IReadOnlyDictionary<string, Setting> GetOverrides() => this.overrideValues ?? new Dictionary<string, Setting>();
 
     private void StartWatch()
     {

--- a/src/ConfigCatClient/Utils/StringListFormatter.cs
+++ b/src/ConfigCatClient/Utils/StringListFormatter.cs
@@ -7,11 +7,11 @@ namespace ConfigCat.Client.Utils;
 
 internal readonly struct StringListFormatter : IFormattable
 {
-    private readonly ICollection<string> collection;
+    private readonly IReadOnlyCollection<string> collection;
     private readonly int maxLength;
     private readonly Func<int, string>? getOmittedItemsText;
 
-    public StringListFormatter(ICollection<string> collection, int maxLength = 0, Func<int, string>? getOmittedItemsText = null)
+    public StringListFormatter(IReadOnlyCollection<string> collection, int maxLength = 0, Func<int, string>? getOmittedItemsText = null)
     {
         this.collection = collection;
         this.maxLength = maxLength;


### PR DESCRIPTION
### Describe the purpose of your pull request
Exposes `IOverrideDataSource` and a public `FlagOverrides` constructor to consumers, allowing them to implement custom data sources.

### Related issues (only if applicable)
https://trello.com/c/Wc4qxVkE

### How to test? (only if applicable)
n/a

### Security (only if applicable)
n/a

### Requirement checklist (only if applicable)
- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
