### PR TITLE
Replace the outdated InheritDocTool with a newer alternative

### DIFF
--- a/.github/workflows/dotnet-sdk-ci.yml
+++ b/.github/workflows/dotnet-sdk-ci.yml
@@ -83,14 +83,7 @@ jobs:
 
     - uses: actions/setup-dotnet@v5
       with:
-        # The .NET Core 3.1 SDK needs to be present for InheritDocTool.
-        dotnet-version: |
-          3.1.x
-          10.0.x
-
-    - name: Install InheritDocTool
-      run: |
-        dotnet tool install InheritDocTool -g
+        dotnet-version: 10.0.x
 
     - name: Determine version
       run: |
@@ -103,10 +96,6 @@ jobs:
     - name: Build
       run: |
         dotnet build src/ConfigCatClient.sln -c Release /p:ContinuousIntegrationBuild=true /p:Version=$VERSION
-
-    - name: Run InheritDocTool
-      run: |
-        InheritDoc -o
 
     - name: Pack
       run: |

--- a/src/ConfigCatClient/ConfigCatClient.cs
+++ b/src/ConfigCatClient/ConfigCatClient.cs
@@ -81,7 +81,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         return key.Sha1().ToHexString();
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public LogLevel LogLevel
     {
         get => Logger.LogLevel;
@@ -226,7 +226,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         return instance;
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     ~ConfigCatClient()
     {
         // Safeguard against situations where user forgets to dispose the client instance.
@@ -268,7 +268,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         }
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public void Dispose()
     {
         if (this.sdkKey is not null)
@@ -309,7 +309,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         }
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     [Obsolete("This method may lead to an unresponsive application (see remarks), thus it will be removed from the public API in a future major version. Please use either the async version of the method or snaphots.")]
     public T GetValue<T>(string key, T defaultValue, User? user = null)
     {
@@ -347,7 +347,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         return value;
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public async Task<T> GetValueAsync<T>(string key, T defaultValue, User? user = null, CancellationToken cancellationToken = default)
     {
         if (key is null)
@@ -388,7 +388,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         return value;
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     [Obsolete("This method may lead to an unresponsive application (see remarks), thus it will be removed from the public API in a future major version. Please use either the async version of the method or snaphots.")]
     public EvaluationDetails<T> GetValueDetails<T>(string key, T defaultValue, User? user = null)
     {
@@ -423,7 +423,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         return evaluationDetails;
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public async Task<EvaluationDetails<T>> GetValueDetailsAsync<T>(string key, T defaultValue, User? user = null, CancellationToken cancellationToken = default)
     {
         if (key is null)
@@ -461,7 +461,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         return evaluationDetails;
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     [Obsolete("This method may lead to an unresponsive application (see remarks), thus it will be removed from the public API in a future major version. Please use either the async version of the method or snaphots.")]
     public IReadOnlyCollection<string> GetAllKeys()
     {
@@ -482,7 +482,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         }
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public async Task<IReadOnlyCollection<string>> GetAllKeysAsync(CancellationToken cancellationToken = default)
     {
         const string defaultReturnValue = "empty collection";
@@ -506,7 +506,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         }
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     [Obsolete("This method may lead to an unresponsive application (see remarks), thus it will be removed from the public API in a future major version. Please use either the async version of the method or snaphots.")]
     public IReadOnlyDictionary<string, object?> GetAllValues(User? user = null)
     {
@@ -540,7 +540,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         return result;
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public async Task<IReadOnlyDictionary<string, object?>> GetAllValuesAsync(User? user = null, CancellationToken cancellationToken = default)
     {
         const string defaultReturnValue = "empty dictionary";
@@ -577,7 +577,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         return result;
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     [Obsolete("This method may lead to an unresponsive application (see remarks), thus it will be removed from the public API in a future major version. Please use either the async version of the method or snaphots.")]
     public IReadOnlyList<EvaluationDetails> GetAllValueDetails(User? user = null)
     {
@@ -609,7 +609,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         return evaluationDetailsArray;
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public async Task<IReadOnlyList<EvaluationDetails>> GetAllValueDetailsAsync(User? user = null, CancellationToken cancellationToken = default)
     {
         const string defaultReturnValue = "empty list";
@@ -644,7 +644,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         return evaluationDetailsArray;
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     [Obsolete("This method may lead to an unresponsive application (see remarks), thus it will be removed from the public API in a future major version. Please use either the async version of the method or snaphots.")]
     public KeyValuePair<string, T>? GetKeyAndValue<T>(string variationId)
     {
@@ -673,7 +673,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         }
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public async Task<KeyValuePair<string, T>?> GetKeyAndValueAsync<T>(string variationId, CancellationToken cancellationToken = default)
     {
         if (variationId is null)
@@ -705,7 +705,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         }
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     [Obsolete("This method may lead to an unresponsive application (see remarks), thus it will be removed from the public API in a future major version. Please use either the async version of the method or snaphots.")]
     public RefreshResult ForceRefresh()
     {
@@ -720,7 +720,7 @@ public sealed class ConfigCatClient : IConfigCatClient
         }
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public async Task<RefreshResult> ForceRefreshAsync(CancellationToken cancellationToken = default)
     {
         try
@@ -802,19 +802,19 @@ public sealed class ConfigCatClient : IConfigCatClient
         }
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public void SetDefaultUser(User user)
     {
         this.defaultUser = user ?? throw new ArgumentNullException(nameof(user));
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public Task<ClientCacheState> WaitForReadyAsync(CancellationToken cancellationToken = default)
     {
         return this.configService.ReadyTask.WaitAsync(cancellationToken);
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public ConfigCatClientSnapshot Snapshot()
     {
         SettingsWithRemoteConfig settings;
@@ -832,22 +832,22 @@ public sealed class ConfigCatClient : IConfigCatClient
         }
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public void ClearDefaultUser()
     {
         this.defaultUser = null;
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public bool IsOffline => this.configService.IsOffline;
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public void SetOnline()
     {
         this.configService.SetOnline();
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public void SetOffline()
     {
         this.configService.SetOffline();

--- a/src/ConfigCatClient/ConfigCatClient.csproj
+++ b/src/ConfigCatClient/ConfigCatClient.csproj
@@ -96,6 +96,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
+    <PackageReference Include="SauceControl.InheritDoc" Version="2.0.2" PrivateAssets="all" />
     <None Include="icon.png" Pack="true" Visible="false" PackagePath="" />
     <None Include="..\..\README.md" Pack="true" PackagePath="" />
   </ItemGroup>

--- a/src/ConfigCatClient/ConfigCatClientSnapshot.cs
+++ b/src/ConfigCatClient/ConfigCatClientSnapshot.cs
@@ -37,17 +37,17 @@ public readonly struct ConfigCatClientSnapshot : IConfigCatClientSnapshot
         this.cacheState = default;
     }
 
-    /// <inheritdoc/>>
+    /// <inheritdoc/>
     public ClientCacheState CacheState => this.evaluationServicesOrFakeImpl is EvaluationServices
         ? this.cacheState
         : ((IConfigCatClientSnapshot?)this.evaluationServicesOrFakeImpl)?.CacheState ?? ClientCacheState.NoFlagData;
 
-    /// <inheritdoc/>>
+    /// <inheritdoc/>
     public IConfig? FetchedConfig => this.evaluationServicesOrFakeImpl is EvaluationServices
         ? this.settings.RemoteConfig?.Config
         : ((IConfigCatClientSnapshot?)this.evaluationServicesOrFakeImpl)?.FetchedConfig ?? null;
 
-    /// <inheritdoc/>>
+    /// <inheritdoc/>
     public IReadOnlyCollection<string> GetAllKeys()
     {
         if (this.evaluationServicesOrFakeImpl is not EvaluationServices)
@@ -60,7 +60,7 @@ public readonly struct ConfigCatClientSnapshot : IConfigCatClientSnapshot
         return this.settings.Value is { } settings ? settings.ReadOnlyKeys() : ArrayUtils.EmptyArray<string>();
     }
 
-    /// <inheritdoc/>>
+    /// <inheritdoc/>
     public T GetValue<T>(string key, T defaultValue, User? user = null)
     {
         if (this.evaluationServicesOrFakeImpl is not EvaluationServices evaluationServices)
@@ -104,7 +104,7 @@ public readonly struct ConfigCatClientSnapshot : IConfigCatClientSnapshot
         return value;
     }
 
-    /// <inheritdoc/>>
+    /// <inheritdoc/>
     public EvaluationDetails<T> GetValueDetails<T>(string key, T defaultValue, User? user = null)
     {
         if (this.evaluationServicesOrFakeImpl is not EvaluationServices evaluationServices)
@@ -145,7 +145,7 @@ public readonly struct ConfigCatClientSnapshot : IConfigCatClientSnapshot
         return evaluationDetails;
     }
 
-    /// <inheritdoc/>>
+    /// <inheritdoc/>
     public KeyValuePair<string, T>? GetKeyAndValue<T>(string variationId)
     {
         if (this.evaluationServicesOrFakeImpl is not EvaluationServices evaluationServices)

--- a/src/ConfigCatClient/ConfigService/HttpClientConfigFetcher.cs
+++ b/src/ConfigCatClient/ConfigService/HttpClientConfigFetcher.cs
@@ -91,7 +91,7 @@ public class HttpClientConfigFetcher : IConfigCatConfigFetcher
         this.handlerState = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public void Dispose()
     {
         Dispose(true);
@@ -124,7 +124,7 @@ public class HttpClientConfigFetcher : IConfigCatConfigFetcher
         return new HttpClient(handler, disposeHandler: false) { Timeout = timeout };
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public Task<FetchResponse> FetchAsync(FetchRequest request, CancellationToken cancellationToken) =>
         FetchAsync(request, logger: null, cancellationToken);
 

--- a/src/ConfigCatClient/Logging/ConsoleLogger.cs
+++ b/src/ConfigCatClient/Logging/ConsoleLogger.cs
@@ -10,7 +10,7 @@ public class ConsoleLogger : IConfigCatLogger
 {
     private volatile LogLevel logLevel;
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public LogLevel LogLevel
     {
         get => this.logLevel;
@@ -31,7 +31,7 @@ public class ConsoleLogger : IConfigCatLogger
         LogLevel = logLevel;
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public void Log(LogLevel level, LogEventId eventId, ref FormattableLogMessage message, Exception? exception = null)
     {
         var levelString = level switch

--- a/src/ConfigCatClient/Logging/LogEventId.cs
+++ b/src/ConfigCatClient/Logging/LogEventId.cs
@@ -46,7 +46,7 @@ public readonly struct LogEventId : IEquatable<LogEventId>
     /// </summary>
     public int Id { get; }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public override string ToString()
     {
         return Id.ToString();

--- a/src/ConfigCatClient/Logging/LoggerWrapper.cs
+++ b/src/ConfigCatClient/Logging/LoggerWrapper.cs
@@ -26,7 +26,7 @@ internal sealed class LoggerWrapper : IConfigCatLogger
         return (byte)level <= (byte)LogLevel;
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     public void Log(LogLevel level, LogEventId eventId, ref FormattableLogMessage message, Exception? exception = null)
     {
         if (IsEnabled(level) && (this.filter is null || this.filter(level, eventId, ref message, exception)))


### PR DESCRIPTION
### Describe the purpose of your pull request
The tool used for replacing `<inheritdoc />` references works only on .NET Core 3.1, but that breaks on the lastest Linux GitHub runner image.

### Related issues (only if applicable)
n/a

### How to test? (only if applicable)
n/a

### Security (only if applicable)
n/a

### Requirement checklist (only if applicable)
- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
