### PR TITLE
Improve internal handler lifetime management

### DIFF
--- a/samples/UnityWebGL/Assets/Scripts/SingletonServices.cs
+++ b/samples/UnityWebGL/Assets/Scripts/SingletonServices.cs
@@ -202,7 +202,7 @@ public class SingletonServices : MonoBehaviour
                 }
 
                 // Wait a little before trying again.
-                await TaskShim.Current.Delay(TimeSpan.FromMilliseconds(50), cancellationToken).ConfigureAwait(true);
+                await TaskShim.Current.Delay(TimeSpan.FromMilliseconds(50), cancellationToken);
 
                 logger.LogDebug($"Trying again to fetch config at '{uri}'...");
             }

--- a/src/ConfigCat.Client.Tests/BasicConfigCatClientIntegrationTests.cs
+++ b/src/ConfigCat.Client.Tests/BasicConfigCatClientIntegrationTests.cs
@@ -5,6 +5,8 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using ConfigCat.Client.Configuration;
+using ConfigCat.Client.Shims;
+using ConfigCat.Client.Tests.Fakes;
 using ConfigCat.Client.Tests.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -484,33 +486,82 @@ public class BasicConfigCatClientIntegrationTests
         Assert.AreEqual(expectedValue, actual);
     }
 
-    [TestMethod]
-    public async Task ShouldIncludeRayIdInLogMessagesWhenHttpResponseIsNotSuccessful()
+    [DataTestMethod]
+    [DataRow("404")]
+    [DataRow("408")]
+    [DataRow("timeout")]
+    [DataRow("error")]
+    public async Task ShouldIncludeRayIdInLogMessagesWhenHttpResponseIsNotSuccessful(string testCase)
     {
+        const string rayId = "CF-RAY-123";
+
         var logEvents = new List<LogEvent>();
         var logger = LoggingHelper.CreateCapturingLogger(logEvents, LogLevel.Info);
+
+        Func<FetchRequest, Task<FetchResponse>> fetchCallback;
+        LogEventId expectedEventId;
+
+        switch (testCase)
+        {
+            case "404":
+                fetchCallback = (_) => Task.FromResult(
+                    new FetchResponse(HttpStatusCode.NotFound, "Not Found", new KeyValuePair<string, string>[] { new("CF-RAY", rayId) }));
+                expectedEventId = 1100;
+                break;
+            case "408":
+                fetchCallback = (_) => Task.FromResult(
+                    new FetchResponse(HttpStatusCode.RequestTimeout, "Request Timeout", new KeyValuePair<string, string>[] { new("CF-RAY", rayId) }));
+                expectedEventId = 1101;
+                break;
+            case "timeout":
+                fetchCallback = (_) =>
+                {
+                    var tcs = TaskShim.CreateSafeCompletionSource<FetchResponse>(out var task);
+                    tcs.SetException(new FetchErrorException.Timeout_(default, null, rayId));
+                    return task;
+                };
+                expectedEventId = 1102;
+                break;
+            case "error":
+                fetchCallback = (_) =>
+                {
+                    var tcs = TaskShim.CreateSafeCompletionSource<FetchResponse>(out var task);
+                    tcs.SetException(new FetchErrorException.Failure_(WebExceptionStatus.ConnectFailure, null, rayId));
+                    return task;
+                };
+                expectedEventId = 1103;
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(testCase), testCase, null);
+        }
+
+        var fakeConfigFetcher = new FakeConfigFetcher(fetchCallback);
 
         using IConfigCatClient client = ConfigCatClient.Get("configcat-sdk-1/~~~~~~~~~~~~~~~~~~~~~~/~~~~~~~~~~~~~~~~~~~~~~", options =>
         {
             options.PollingMode = PollingModes.ManualPoll;
             options.Logger = logger;
+            options.ConfigFetcher = fakeConfigFetcher;
         });
 
         await client.ForceRefreshAsync();
 
-        var errors = logEvents.Where(evt => evt.EventId == 1100).ToArray();
-        Assert.AreEqual(1, errors.Length);
+        var events = logEvents.Where(evt => evt.EventId == expectedEventId).ToArray();
+        Assert.AreEqual(1, events.Length);
 
-        var error = errors[0].Message;
-        Assert.AreEqual(2, error.ArgNames.Length);
-        Assert.AreEqual(2, error.ArgValues.Length);
-        Assert.IsTrue(error.ArgValues[0] is string);
-        Assert.IsTrue(error.ArgValues[1] is string);
+        var error = events[0].Message;
+        var message = error.InvariantFormattedMessage;
 
-        var message = errors[0].Message.InvariantFormattedMessage;
-        StringAssert.StartsWith(message, "Your SDK Key seems to be wrong: '***************/**********************/****************~~~~~~'.");
+        if (testCase == "404")
+        {
+            Assert.AreEqual(2, error.ArgNames.Length);
+            Assert.AreEqual(2, error.ArgValues.Length);
+            Assert.IsTrue(error.ArgValues[0] is string);
+            Assert.IsTrue(error.ArgValues[1] is string);
 
-        var rayId = (string)error.ArgValues[0]!;
+            StringAssert.StartsWith(message, "Your SDK Key seems to be wrong: '***************/**********************/****************~~~~~~'.");
+        }
+
         StringAssert.Contains(message, rayId);
     }
 }

--- a/src/ConfigCat.Client.Tests/Fakes/FakeConfigFetcher.cs
+++ b/src/ConfigCat.Client.Tests/Fakes/FakeConfigFetcher.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ConfigCat.Client.Tests.Fakes;
+
+internal sealed class FakeConfigFetcher : IConfigCatConfigFetcher
+{
+    private readonly Func<FetchRequest, Task<FetchResponse>> fetchCallback;
+
+    public FakeConfigFetcher(Func<FetchRequest, Task<FetchResponse>> fetchCallback)
+    {
+        this.fetchCallback = fetchCallback;
+    }
+
+    public void Dispose() { /* intentional no-op */ }
+
+    public Task<FetchResponse> FetchAsync(FetchRequest request, CancellationToken cancellationToken)
+    {
+        return this.fetchCallback(request);
+    }
+}

--- a/src/ConfigCat.Client.Tests/HttpConfigFetcherTests.cs
+++ b/src/ConfigCat.Client.Tests/HttpConfigFetcherTests.cs
@@ -203,11 +203,7 @@ public class HttpConfigFetcherTests
 
         await Assert.ThrowsExceptionAsync<FetchErrorException.Failure_>(() => configFetcher.FetchAsync(fetchRequest, fakeLogger, cancellationToken: default));
 
-        Debug.WriteLine(capturedParams.Count);
-
         await Assert.ThrowsExceptionAsync<FetchErrorException.Failure_>(() => configFetcher.FetchAsync(fetchRequest, fakeLogger, cancellationToken: default));
-
-        Debug.WriteLine(capturedParams.Count);
 
         await Task.Delay(new TimeSpan(handlerRenewalThreshold.Ticks * 3 / 2));
 

--- a/src/ConfigCat.Client.Tests/HttpConfigFetcherTests.cs
+++ b/src/ConfigCat.Client.Tests/HttpConfigFetcherTests.cs
@@ -938,10 +938,15 @@ public class HttpConfigFetcherTests
     [DataRow("file:///configuration-files/configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g/config_v6.json", false)]
     [DataRow("http://cdn-global.configcat.com/configuration-files/configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g/config_v6.json", true)]
     [DataRow("https://cdn-global.configcat.com/configuration-files/configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g/config_v6.json", true)]
+    [DataRow("https://cdn-global.configcat.com/configuration-files/configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g/config_v6.json?x=/configcat-proxy/", true)]
+    [DataRow("https://cdn-global.configcat.com/configuration-files/configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g/config_v6.json?x#/configcat-proxy/", true)]
+    [DataRow("https://cdn-global.configcat.com/configuration-files/configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g/config_v6.json#/configcat-proxy/", true)]
     [DataRow("https://cdn-global.configcat.com/configuration%2dfiles/configcat%2dsdk%2d1/PKDVCLf%2dHq%2dh%2dkCzMp%2dL7Q/u28_1qNyZ0Wz%2dldYHIU7%2dg/config_v6.json", true)]
     [DataRow("https://cdn-global.configcat.com./configuration-files/configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g/config_v6.json", true)]
     [DataRow("https://cdn-global.configcat.com/configcat-proxy/configuration-files/configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g/config_v6.json", false)]
+    [DataRow("https://cdn-global.configcat.com/configcat%2dproxy/configuration-files/configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g/config_v6.json", false)]
     [DataRow("https://cdn-global.configcat.com/configuration-files/configcat-proxy/configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g/config_v6.json", false)]
+    [DataRow("https://cdn-global.configcat.com/configuration-files/configcat%2Dproxy/configcat-sdk-1/PKDVCLf-Hq-h-kCzMp-L7Q/u28_1qNyZ0Wz-ldYHIU7-g/config_v6.json?x", false)]
     public void IsCdnUri_Works(string uri, bool expectedResult)
     {
         // Arrange

--- a/src/ConfigCat.Client.Tests/HttpConfigFetcherTests.cs
+++ b/src/ConfigCat.Client.Tests/HttpConfigFetcherTests.cs
@@ -133,6 +133,8 @@ public class HttpConfigFetcherTests
         try { fetchResponse = await configFetcher.FetchAsync(fetchRequest, fakeLogger, cancellationToken: default); }
         catch (FetchErrorException ex) { fetchErrorException = ex; }
 
+        // Assert
+
         switch (@case)
         {
             case "408":
@@ -145,8 +147,6 @@ public class HttpConfigFetcherTests
                 Assert.IsInstanceOfType(fetchErrorException, typeof(FetchErrorException.Failure_));
                 break;
         }
-
-        // Assert
 
         Assert.AreEqual(2, capturedParams.Count);
 
@@ -401,6 +401,8 @@ public class HttpConfigFetcherTests
         try { fetchResponse = await configFetcher.FetchAsync(fetchRequest, fakeLogger, cancellationToken: default); }
         catch (FetchErrorException ex) { fetchErrorException = ex; }
 
+        // Assert
+
         switch (@case)
         {
             case "408":
@@ -413,8 +415,6 @@ public class HttpConfigFetcherTests
                 Assert.IsInstanceOfType(fetchErrorException, typeof(FetchErrorException.Failure_));
                 break;
         }
-
-        // Assert
 
         Assert.AreEqual(2, capturedParams.Count);
 
@@ -731,7 +731,7 @@ public class HttpConfigFetcherTests
     [DataTestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public async Task HttpClientConfigFetcher_ShouldBeDisposedWhenNotOwned(bool ownConfigFetcher)
+    public async Task HttpClientConfigFetcher_ShouldBeDisposedOnlyWhenOwned(bool ownConfigFetcher)
     {
         // Arrange
 

--- a/src/ConfigCatClient/ConfigService/AutoPollConfigService.cs
+++ b/src/ConfigCatClient/ConfigService/AutoPollConfigService.cs
@@ -206,10 +206,10 @@ internal sealed class AutoPollConfigService : ConfigServiceBase, IConfigService
                         this.Logger.AutoPollConfigServiceErrorDuringPolling(ex);
                     }
 
-                    var realNextTime = scheduledNextTime - DateTimeUtils.GetMonotonicTime();
-                    if (realNextTime > TimeSpan.Zero)
+                    var timeToWait = scheduledNextTime - DateTimeUtils.GetMonotonicTime();
+                    if (timeToWait > TimeSpan.Zero)
                     {
-                        await TaskShim.Current.Delay(realNextTime, stopToken).ConfigureAwait(TaskShim.ContinueOnCapturedContext);
+                        await TaskShim.Current.Delay(timeToWait, stopToken).ConfigureAwait(TaskShim.ContinueOnCapturedContext);
                     }
                 }
                 catch (OperationCanceledException)

--- a/src/ConfigCatClient/ConfigService/HttpClientConfigFetcher.cs
+++ b/src/ConfigCatClient/ConfigService/HttpClientConfigFetcher.cs
@@ -226,14 +226,14 @@ public class HttpClientConfigFetcher : IConfigCatConfigFetcher
                         if (proxy is null || proxy.IsBypassed(request.Uri))
                         {
                             debugLogger.LogInterpolated(LogLevel.Debug, 0,
-                                $"[{requestId}] Sending request... (Uri: '{httpRequest.RequestUri}', IfNoneMatch: '{httpRequest.Headers.IfNoneMatch?.ToString()}')",
-                                "REQUEST_ID", "URI", "IF_NONE_MATCH");
+                                $"[{requestId}] Sending request... (Url: '{httpRequest.RequestUri}', IfNoneMatch: '{httpRequest.Headers.IfNoneMatch?.ToString()}')",
+                                "REQUEST_ID", "URL", "IF_NONE_MATCH");
                         }
                         else
                         {
                             debugLogger.LogInterpolated(LogLevel.Debug, 0,
-                                $"[{requestId}] Sending request via proxy '{proxy.GetProxy(request.Uri)}'... (Uri: '{httpRequest.RequestUri}', IfNoneMatch: '{httpRequest.Headers.IfNoneMatch?.ToString()}')",
-                                "REQUEST_ID", "PROXY_URI", "URI", "IF_NONE_MATCH");
+                                $"[{requestId}] Sending request via proxy '{proxy.GetProxy(request.Uri)}'... (Url: '{httpRequest.RequestUri}', IfNoneMatch: '{httpRequest.Headers.IfNoneMatch?.ToString()}')",
+                                "REQUEST_ID", "PROXY_URL", "URL", "IF_NONE_MATCH");
                         }
                     }
 

--- a/src/ConfigCatClient/ConfigService/HttpClientConfigFetcher.cs
+++ b/src/ConfigCatClient/ConfigService/HttpClientConfigFetcher.cs
@@ -130,7 +130,7 @@ public class HttpClientConfigFetcher : IConfigCatConfigFetcher
 
     internal async Task<FetchResponse> FetchAsync(FetchRequest request, LoggerWrapper? logger, CancellationToken cancellationToken)
     {
-        var isDebugLoggingEnabled = logger is not null && logger.IsEnabled(LogLevel.Debug);
+        var debugLogger = logger is not null && logger.IsEnabled(LogLevel.Debug) ? logger : null;
 
 #if NET45
         Guid requestId = default;
@@ -138,11 +138,11 @@ public class HttpClientConfigFetcher : IConfigCatConfigFetcher
         Unsafe.SkipInit(out Guid requestId);
 #endif
 
-        if (isDebugLoggingEnabled)
+        if (debugLogger is not null)
         {
             requestId = Guid.NewGuid();
 
-            logger!.LogInterpolated(LogLevel.Debug, 0,
+            debugLogger.LogInterpolated(LogLevel.Debug, 0,
                 $"[{requestId}] Preparing request...",
                 "REQUEST_ID");
         }
@@ -180,7 +180,6 @@ public class HttpClientConfigFetcher : IConfigCatConfigFetcher
         try
         {
             const int retryLimit = 1;
-            bool canRetry;
 
             for (var retryCount = 0; ; retryCount++)
             {
@@ -212,20 +211,27 @@ public class HttpClientConfigFetcher : IConfigCatConfigFetcher
                 }
 
                 string? rayId = null;
+                var shouldRenewHandler = false;
+
+                if (handlerState is not null)
+                {
+                    StartRequestWithInternalHandler(ref handlerState, ref handlerStateObj, ref httpClient, request);
+                }
+
                 try
                 {
-                    if (isDebugLoggingEnabled)
+                    if (debugLogger is not null)
                     {
                         var proxy = handlerState is not null ? handlerState.Proxy : (handlerStateObj as HttpClientHandler)?.Proxy;
                         if (proxy is null || proxy.IsBypassed(request.Uri))
                         {
-                            logger!.LogInterpolated(LogLevel.Debug, 0,
+                            debugLogger.LogInterpolated(LogLevel.Debug, 0,
                                 $"[{requestId}] Sending request... (Uri: '{httpRequest.RequestUri}', IfNoneMatch: '{httpRequest.Headers.IfNoneMatch?.ToString()}')",
                                 "REQUEST_ID", "URI", "IF_NONE_MATCH");
                         }
                         else
                         {
-                            logger!.LogInterpolated(LogLevel.Debug, 0,
+                            debugLogger.LogInterpolated(LogLevel.Debug, 0,
                                 $"[{requestId}] Sending request via proxy '{proxy.GetProxy(request.Uri)}'... (Uri: '{httpRequest.RequestUri}', IfNoneMatch: '{httpRequest.Headers.IfNoneMatch?.ToString()}')",
                                 "REQUEST_ID", "PROXY_URI", "URI", "IF_NONE_MATCH");
                         }
@@ -234,12 +240,9 @@ public class HttpClientConfigFetcher : IConfigCatConfigFetcher
                     using var httpResponse = await httpClient.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                         .ConfigureAwait(TaskShim.ContinueOnCapturedContext);
 
-                    if (isDebugLoggingEnabled)
-                    {
-                        logger!.LogInterpolated(LogLevel.Debug, 0,
-                            $"[{requestId}] Received headers. (StatusCode: {(int)httpResponse.StatusCode}, ReasonPhrase: '{httpResponse.ReasonPhrase}', ETag: '{httpResponse.Headers.ETag?.ToString()}')",
-                            "REQUEST_ID", "STATUS_CODE", "REASON_PHRASE", "ETAG");
-                    }
+                    debugLogger?.LogInterpolated(LogLevel.Debug, 0,
+                        $"[{requestId}] Received headers. (StatusCode: {(int)httpResponse.StatusCode}, ReasonPhrase: '{httpResponse.ReasonPhrase}', ETag: '{httpResponse.Headers.ETag?.ToString()}')",
+                        "REQUEST_ID", "STATUS_CODE", "REASON_PHRASE", "ETAG");
 
                     rayId = FetchResponse.GetRayId(httpResponse.Headers);
 
@@ -251,12 +254,9 @@ public class HttpClientConfigFetcher : IConfigCatConfigFetcher
                         var httpResponseBody = await httpResponse.Content.ReadAsStringAsync().WaitAsync(cancellationToken).ConfigureAwait(TaskShim.ContinueOnCapturedContext);
 #endif
 
-                        if (isDebugLoggingEnabled)
-                        {
-                            logger!.LogInterpolated(LogLevel.Debug, 0,
-                                $"[{requestId}] Received body. (Length: {httpResponseBody.Length})",
-                                "REQUEST_ID", "LENGTH");
-                        }
+                        debugLogger?.LogInterpolated(LogLevel.Debug, 0,
+                            $"[{requestId}] Received body. (Length: {httpResponseBody.Length})",
+                            "REQUEST_ID", "LENGTH");
 
                         return new FetchResponse(httpResponse, rayId, httpResponseBody);
                     }
@@ -268,16 +268,13 @@ public class HttpClientConfigFetcher : IConfigCatConfigFetcher
                             return response;
                         }
 
-                        if (isDebugLoggingEnabled)
-                        {
-                            logger!.LogInterpolated(LogLevel.Debug, 0,
-                                $"[{requestId}] Received unexpected status code.",
-                                "REQUEST_ID");
-                        }
+                        shouldRenewHandler = true;
 
-                        canRetry = retryCount < retryLimit;
-                        RenewClient(ref httpClient, ref handlerState, ref handlerStateObj, requestId, request, canRetry);
-                        if (!canRetry)
+                        debugLogger?.LogInterpolated(LogLevel.Debug, 0,
+                            $"[{requestId}] Received unexpected status code.",
+                            "REQUEST_ID");
+
+                        if (retryCount >= retryLimit)
                         {
                             return response;
                         }
@@ -292,16 +289,13 @@ public class HttpClientConfigFetcher : IConfigCatConfigFetcher
                 }
                 catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
                 {
-                    if (isDebugLoggingEnabled)
-                    {
-                        logger!.LogInterpolated(LogLevel.Debug, 0, ex,
-                            $"[{requestId}] Request timed out.",
-                            "REQUEST_ID");
-                    }
+                    shouldRenewHandler = true;
 
-                    canRetry = retryCount < retryLimit;
-                    RenewClient(ref httpClient, ref handlerState, ref handlerStateObj, requestId, request, canRetry);
-                    if (!canRetry)
+                    debugLogger?.LogInterpolated(LogLevel.Debug, 0, ex,
+                        $"[{requestId}] Request timed out.",
+                        "REQUEST_ID");
+
+                    if (retryCount >= retryLimit)
                     {
                         throw new FetchErrorException.Timeout_(httpClient.Timeout, ex, rayId);
                     }
@@ -313,125 +307,156 @@ public class HttpClientConfigFetcher : IConfigCatConfigFetcher
                 }
                 catch (HttpRequestException ex)
                 {
-                    if (isDebugLoggingEnabled)
-                    {
-                        logger!.LogInterpolated(LogLevel.Debug, 0, ex,
-                            $"[{requestId}] Request failed.",
-                            "REQUEST_ID");
-                    }
+                    shouldRenewHandler = true;
 
-                    canRetry = retryCount < retryLimit;
-                    RenewClient(ref httpClient, ref handlerState, ref handlerStateObj, requestId, request, canRetry);
-                    if (!canRetry)
+                    debugLogger?.LogInterpolated(LogLevel.Debug, 0, ex,
+                        $"[{requestId}] Request failed.",
+                        "REQUEST_ID");
+
+                    if (retryCount >= retryLimit)
                     {
                         throw new FetchErrorException.Failure_((ex.InnerException as WebException)?.Status, ex, rayId);
+                    }
+                }
+                finally
+                {
+                    if (handlerState is not null)
+                    {
+                        FinishRequestWithInternalHandler(handlerState, shouldRenewHandler, requestId, debugLogger);
                     }
                 }
 
                 // Wait a little before trying again.
                 await TaskShim.Current.Delay(this.requestRetryDelay, cancellationToken).ConfigureAwait(TaskShim.ContinueOnCapturedContext);
 
-                if (isDebugLoggingEnabled)
+                debugLogger?.LogInterpolated(LogLevel.Debug, 0,
+                    $"[{requestId}] Trying request again...",
+                    "REQUEST_ID");
+
+                handlerStateObj = this.handlerState;
+                if (handlerStateObj is null)
                 {
-                    logger!.LogInterpolated(LogLevel.Debug, 0,
-                        $"[{requestId}] Trying request again...",
-                        "REQUEST_ID");
+                    throw WrapObjectDisposedException(new ObjectDisposedException(nameof(HttpClientConfigFetcher)));
+                }
+                else if (handlerState is not null)
+                {
+                    if (!ReferenceEquals(handlerState, handlerStateObj))
+                    {
+                        // If the handler has changed, create a new client so it can pick up potentially changed DNS entries.
+                        // See also: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines#dns-behavior
+
+                        handlerState = (HandlerState)handlerStateObj;
+                        httpClient.Dispose();
+                        httpClient = CreateHttpClient(handlerState.Handler, request.Timeout);
+                    }
+                }
+                else if (handlerStateObj is HttpClientFactory httpClientFactory)
+                {
+                    // If the client is created externally, give consumer the opportunity to create another instance for the retry.
+
+                    httpClient.Dispose();
+                    httpClient = httpClientFactory(request, isRetry: true);
                 }
             }
         }
-        finally { httpClient.Dispose(); }
+        finally { httpClient?.Dispose(); }
 
-        void RenewClient(ref HttpClient httpClient, ref HandlerState? handlerState, ref object? handlerStateObj, in Guid requestId,
-            in FetchRequest request, bool canRetry)
+        void StartRequestWithInternalHandler(ref HandlerState handlerState, ref object? handlerStateObj, ref HttpClient httpClient, FetchRequest request)
         {
-            // Attempt to renew the client so it can pick up potentially changed DNS entries.
-            // See also: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines#dns-behavior
+            // Increase the NumRequestsInProgress counter by one atomically.
+            // NOTE: We can't simply use Interlocked.Increment as we need to check for negative values.
 
-            if (handlerState is not null)
+            for (; ; )
             {
-                // If handler is managed internally, try to renew the handler, i.e. create another connection pool.
+                var initialNumRequests = Volatile.Read(ref handlerState.NumRequestsInProgress);
 
-                if (handlerState.TimeElapsedSinceLastRenew < this.handlerRenewalThreshold)
+                for (; ; )
                 {
+                    if (initialNumRequests < 0)
+                    {
+                        break; // disposed handler detected
+                    }
+
+                    var currentNumRequests = Interlocked.CompareExchange(ref handlerState.NumRequestsInProgress, value: initialNumRequests + 1, comparand: initialNumRequests);
+                    if (currentNumRequests >= 0 && currentNumRequests == initialNumRequests)
+                    {
+                        return; // counter incremented successfully
+                    }
+
+                    // a concurrent modification to the counter detected, try again
+                    initialNumRequests = currentNumRequests;
+                }
+
+                // Handle edge case caused by the following race condition:
+                // 1. The current operation reads this.handlerState before starting the request in FetchAsync.
+                // 2. Afterwards, another operation renews the handler and replaces this.handlerState in FinishRequestWithInternalHandler.
+                // 3. That or another operation brings the NumRequestsInProgress counter below zero in FinishRequestWithInternalHandler,
+                //    indicating that the handler shouldn't be used anymore.
+                // 4. The current operation now wants to increase the counter and start a request.
+                // To resolve the situation, get the new handler and try again.
+
+                handlerStateObj = this.handlerState;
+                if (handlerStateObj is null)
+                {
+                    throw WrapObjectDisposedException(new ObjectDisposedException(nameof(HttpClientConfigFetcher)));
+                }
+                else if (ReferenceEquals(handlerStateObj, handlerState))
+                {
+                    // Execution should never get here. If it does, there's a bug in FinishRequestWithInternalHandler.
+                    // Just to be sure, throw an exception to avoid getting stuck in a potential infinite loop.
+                    throw new InvalidOperationException();
+                }
+
+                handlerState = (HandlerState)handlerStateObj;
+                httpClient.Dispose();
+                httpClient = CreateHttpClient(handlerState.Handler, request.Timeout);
+            }
+        }
+
+        void FinishRequestWithInternalHandler(HandlerState handlerState, bool shouldRenewHandler, in Guid requestId, LoggerWrapper? debugLogger)
+        {
+            var numRequestsToAdd = -1;
+            try
+            {
+                if (shouldRenewHandler && handlerState.CanRenew(this.handlerRenewalThreshold))
+                {
+                    // Try to renew the handler, i.e. create another connection pool.
+
                     // NOTE: The new handler implementation (SocketsHttpHandler) doesn't immediately close the connections in
                     // the pool on dispose but keeps them around for some time in the TIME_WAIT state, according to RFC 9293.
                     // The exact length of this period depends on OS settings but usually it's 1-4 min. A reasonable threshold
                     // for recreating handlers should be enough to avoid socket exhaustion, even in extreme cases.
                     // See also: https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines#pooled-connections
 
-                    handlerStateObj = this.handlerState;
-                    CheckNotDisposed(handlerStateObj, throwIfDisposed: canRetry);
-                    return;
-                }
-
-                var renewedHandlerState = handlerState.Renew();
-                handlerStateObj = Interlocked.CompareExchange(ref this.handlerState, value: renewedHandlerState, comparand: handlerState);
-                if (ReferenceEquals(handlerStateObj, handlerState))
-                {
-                    // NOTE: We deliberately don't dispose the original handler as that would make potential pending requests
-                    // running concurrently fail. Instead, we leave it up to the handler's finalizer to clean up unmanaged
-                    // resources when requests are completed and the handler is collected by GC.
-
-                    handlerState = renewedHandlerState;
-                }
-                else
-                {
-                    renewedHandlerState.Handler.Dispose(); // just in case, although this instance wasn't used at all
-
-                    if (CheckNotDisposed(handlerStateObj, throwIfDisposed: canRetry))
+                    var renewedHandlerState = handlerState.Renew();
+                    var currentHandlerState = Interlocked.CompareExchange(ref this.handlerState, value: renewedHandlerState, comparand: handlerState);
+                    if (ReferenceEquals(currentHandlerState, handlerState))
                     {
-                        handlerState = (HandlerState)handlerStateObj!;
+                        // This will cause the NumRequestsInProgress counter to go below zero eventually, indicating that a new
+                        // handler has been created and the original one is not to be used anymore as it will be disposed (see below).
+                        numRequestsToAdd = -2;
+
+                        debugLogger?.LogInterpolated(LogLevel.Debug, 0,
+                            $"[{requestId}] Renewed internal handler.",
+                            "REQUEST_ID");
                     }
                     else
                     {
-                        return;
+                        renewedHandlerState.Handler.Dispose(); // just in case, although this instance wasn't used at all
                     }
                 }
-
-                if (!canRetry)
-                {
-                    return;
-                }
-
-                httpClient.Dispose();
-                httpClient = CreateHttpClient(handlerState.Handler, request.Timeout);
             }
-            else
+            finally
             {
-                handlerStateObj = this.handlerState;
-                if (handlerStateObj is HttpClientFactory httpClientFactory)
+                if (Interlocked.Add(ref handlerState.NumRequestsInProgress, numRequestsToAdd) < 0)
                 {
-                    if (!canRetry)
-                    {
-                        return;
-                    }
+                    handlerState.Handler.Dispose();
 
-                    // If client is created externally, give consumer the opportunity to create another instance for retrying.
-
-                    httpClient.Dispose();
-                    httpClient = httpClientFactory(request, isRetry: true);
-                }
-                else
-                {
-                    CheckNotDisposed(handlerStateObj, throwIfDisposed: canRetry);
-                    return;
+                    debugLogger?.LogInterpolated(LogLevel.Debug, 0,
+                        $"[{requestId}] Disposed out-of-use internal handler.",
+                        "REQUEST_ID");
                 }
             }
-
-            if (isDebugLoggingEnabled)
-            {
-                logger!.LogInterpolated(LogLevel.Debug, 0,
-                    $"[{requestId}] Renewed HttpClient.",
-                    "REQUEST_ID");
-            }
-        }
-
-        static bool CheckNotDisposed(object? handlerStateObj, bool throwIfDisposed)
-        {
-            return
-                handlerStateObj is not null ? true
-                : !throwIfDisposed ? false
-                : throw WrapObjectDisposedException(new ObjectDisposedException(nameof(HttpClientConfigFetcher)));
         }
 
         static OperationCanceledException WrapObjectDisposedException(ObjectDisposedException ex)
@@ -499,13 +524,14 @@ public class HttpClientConfigFetcher : IConfigCatConfigFetcher
     private sealed class HandlerState
     {
         public readonly HttpClientHandler Handler;
+        public int NumRequestsInProgress; // a negative value indicates that the handler shouldn't be used anymore
         public readonly IWebProxy? Proxy;
-        private readonly TimeSpan updateTime;
+        private readonly TimeSpan renewalTime;
 
         public HandlerState(IWebProxy? proxy = null)
             : this(proxy, TimeSpan.MinValue) { }
 
-        private HandlerState(IWebProxy? proxy, TimeSpan updateTime)
+        private HandlerState(IWebProxy? proxy, TimeSpan renewalTime)
         {
             var handler = new HttpClientHandler();
 
@@ -523,12 +549,14 @@ public class HttpClientConfigFetcher : IConfigCatConfigFetcher
             // NOTE: We can't safely access the proxy instance via this.Handler.Proxy as the getter of that property may
             // throw on some platforms (e.g. in browser).
             this.Proxy = proxy;
-            this.updateTime = updateTime;
+            this.renewalTime = renewalTime;
         }
 
-        public TimeSpan TimeElapsedSinceLastRenew => this.updateTime > TimeSpan.MinValue
-            ? DateTimeUtils.GetMonotonicTime() - this.updateTime
-            : TimeSpan.MaxValue;
+        public bool CanRenew(TimeSpan threshold)
+        {
+            return this.renewalTime == TimeSpan.MinValue
+                || DateTimeUtils.GetMonotonicTime() - this.renewalTime >= threshold;
+        }
 
         public HandlerState Renew() => new(this.Proxy, DateTimeUtils.GetMonotonicTime());
     }

--- a/src/ConfigCatClient/ConfigService/HttpClientConfigFetcher.cs
+++ b/src/ConfigCatClient/ConfigService/HttpClientConfigFetcher.cs
@@ -282,6 +282,8 @@ public class HttpClientConfigFetcher : IConfigCatConfigFetcher
                 }
                 catch (ObjectDisposedException ex)
                 {
+                    LogRequestAborted(debugLogger, requestId, ex);
+
                     // It is possible that the handler is disposed between obtaining the reference and the call to SendAsync.
                     // In such cases SendAsync will throw an ObjectDisposedException. Wrap it in an OperationCanceledException
                     // and let callers deal with it.
@@ -300,8 +302,10 @@ public class HttpClientConfigFetcher : IConfigCatConfigFetcher
                         throw new FetchErrorException.Timeout_(httpClient.Timeout, ex, rayId);
                     }
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException ex)
                 {
+                    LogRequestAborted(debugLogger, requestId, ex);
+
                     // If the cancellation has been requested externally, let the exception bubble up.
                     throw;
                 }
@@ -457,6 +461,13 @@ public class HttpClientConfigFetcher : IConfigCatConfigFetcher
                         "REQUEST_ID");
                 }
             }
+        }
+
+        static void LogRequestAborted(LoggerWrapper? debugLogger, in Guid requestId, Exception ex)
+        {
+            debugLogger?.LogInterpolated(LogLevel.Debug, 0, ex,
+                $"[{requestId}] Request aborted.",
+                "REQUEST_ID");
         }
 
         static OperationCanceledException WrapObjectDisposedException(ObjectDisposedException ex)

--- a/src/ConfigCatClient/ConfigService/HttpClientConfigFetcher.cs
+++ b/src/ConfigCatClient/ConfigService/HttpClientConfigFetcher.cs
@@ -393,7 +393,7 @@ public class HttpClientConfigFetcher : IConfigCatConfigFetcher
                     }
 
                     var currentNumRequests = Interlocked.CompareExchange(ref handlerState.NumRequestsInProgress, value: initialNumRequests + 1, comparand: initialNumRequests);
-                    if (currentNumRequests >= 0 && currentNumRequests == initialNumRequests)
+                    if (currentNumRequests == initialNumRequests)
                     {
                         return; // counter incremented successfully
                     }

--- a/src/ConfigCatClient/ConfigService/HttpClientConfigFetcher.cs
+++ b/src/ConfigCatClient/ConfigService/HttpClientConfigFetcher.cs
@@ -226,13 +226,13 @@ public class HttpClientConfigFetcher : IConfigCatConfigFetcher
                         if (proxy is null || proxy.IsBypassed(request.Uri))
                         {
                             debugLogger.LogInterpolated(LogLevel.Debug, 0,
-                                $"[{requestId}] Sending request... (Url: '{httpRequest.RequestUri}', IfNoneMatch: '{httpRequest.Headers.IfNoneMatch?.ToString()}')",
+                                $"[{requestId}] Sending request... (Url: '{httpRequest.RequestUri}', If-None-Match: '{httpRequest.Headers.IfNoneMatch?.ToString()}')",
                                 "REQUEST_ID", "URL", "IF_NONE_MATCH");
                         }
                         else
                         {
                             debugLogger.LogInterpolated(LogLevel.Debug, 0,
-                                $"[{requestId}] Sending request via proxy '{proxy.GetProxy(request.Uri)}'... (Url: '{httpRequest.RequestUri}', IfNoneMatch: '{httpRequest.Headers.IfNoneMatch?.ToString()}')",
+                                $"[{requestId}] Sending request via proxy '{proxy.GetProxy(request.Uri)}'... (Url: '{httpRequest.RequestUri}', If-None-Match: '{httpRequest.Headers.IfNoneMatch?.ToString()}')",
                                 "REQUEST_ID", "PROXY_URL", "URL", "IF_NONE_MATCH");
                         }
                     }
@@ -363,7 +363,7 @@ public class HttpClientConfigFetcher : IConfigCatConfigFetcher
                 }
             }
         }
-        finally { httpClient?.Dispose(); }
+        finally { httpClient.Dispose(); }
 
         void StartRequestWithInternalHandler(ref HandlerState handlerState, ref object? handlerStateObj, ref HttpClient httpClient, FetchRequest request)
         {
@@ -372,7 +372,7 @@ public class HttpClientConfigFetcher : IConfigCatConfigFetcher
 
             for (; ; )
             {
-                var initialNumRequests = Volatile.Read(ref handlerState.NumRequestsInProgress);
+                var initialNumRequests = handlerState.NumRequestsInProgress;
 
                 for (; ; )
                 {
@@ -535,7 +535,7 @@ public class HttpClientConfigFetcher : IConfigCatConfigFetcher
     private sealed class HandlerState
     {
         public readonly HttpClientHandler Handler;
-        public int NumRequestsInProgress; // a negative value indicates that the handler shouldn't be used anymore
+        public volatile int NumRequestsInProgress; // a negative value indicates that the handler shouldn't be used anymore
         public readonly IWebProxy? Proxy;
         private readonly TimeSpan renewalTime;
 

--- a/src/ConfigCatClient/ConfigService/HttpClientConfigFetcher.cs
+++ b/src/ConfigCatClient/ConfigService/HttpClientConfigFetcher.cs
@@ -237,6 +237,8 @@ public class HttpClientConfigFetcher : IConfigCatConfigFetcher
                         }
                     }
 
+                    var requestStartTime = DateTimeUtils.GetMonotonicTime();
+
                     using var httpResponse = await httpClient.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
                         .ConfigureAwait(TaskShim.ContinueOnCapturedContext);
 
@@ -248,10 +250,19 @@ public class HttpClientConfigFetcher : IConfigCatConfigFetcher
 
                     if (httpResponse.StatusCode == HttpStatusCode.OK)
                     {
+                        var remainingTimeout = httpClient.Timeout - (DateTimeUtils.GetMonotonicTime() - requestStartTime);
+                        if (remainingTimeout <= TimeSpan.Zero)
+                        {
+                            new CancellationToken(canceled: true).ThrowIfCancellationRequested();
+                        }
+
+                        using var timeoutCts = new CancellationTokenSource(remainingTimeout);
+                        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, cancellationToken);
+
 #if NET5_0_OR_GREATER
-                        var httpResponseBody = await httpResponse.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(TaskShim.ContinueOnCapturedContext);
+                        var httpResponseBody = await httpResponse.Content.ReadAsStringAsync(linkedCts.Token).ConfigureAwait(TaskShim.ContinueOnCapturedContext);
 #else
-                        var httpResponseBody = await httpResponse.Content.ReadAsStringAsync().WaitAsync(cancellationToken).ConfigureAwait(TaskShim.ContinueOnCapturedContext);
+                        var httpResponseBody = await httpResponse.Content.ReadAsStringAsync().WaitAsync(linkedCts.Token).ConfigureAwait(TaskShim.ContinueOnCapturedContext);
 #endif
 
                         debugLogger?.LogInterpolated(LogLevel.Debug, 0,

--- a/src/ConfigCatClient/Configuration/ConfigCatClientOptions.cs
+++ b/src/ConfigCatClient/Configuration/ConfigCatClientOptions.cs
@@ -43,7 +43,20 @@ public class ConfigCatClientOptions : IProvidesHooks
     /// If you want to use a custom config fetcher, you can provide an implementation of <see cref="IConfigCatConfigFetcher"/>.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Please note that the SDK does not dispose externally created config fetcher instances.
+    /// </para>
+    /// <para>
+    /// Also be aware that implementing a config fetcher that makes HTTP requests to the ConfigCat CDN is tricky, especially when
+    /// the SDK runs in a browser. Therefore, please <b>avoid writing actual config fetcher implementations from scratch</b>
+    /// unless absolutely necessary and you know exactly what you are doing. (Writing mock implementations for testing
+    /// purposes is fine, of course.)
+    /// </para>
+    /// <para>
+    /// If you use the SDK with <see href="https://configcat.com/docs/advanced/proxy/proxy-overview/">ConfigCat Proxy</see> and need to set
+    /// custom HTTP request headers, you can subclass the built-in config fetcher implementation (<see cref="HttpClientConfigFetcher"/>)
+    /// and override the <see cref="HttpClientConfigFetcher.SetRequestHeaders"/> method.
+    /// </para>
     /// </remarks>
     public IConfigCatConfigFetcher? ConfigFetcher { get; set; }
 


### PR DESCRIPTION
### Describe the purpose of your pull request
Originally, `HttpClientConfigFetcher` relied on the garbage collector to clean up out-of-use `HttpClientHandler` objects (along with their underlying connection pools), which is problematic because GC is non-deterministic. Depending on the GC strategy used, cleanup may occur after a long time (or not at all if GC is disabled). This could cause open connections to pile up, leading to potential socket exhaustion.

This PR implements a deterministic algorithm for cleaning up out-of-use handlers.

Also, fixes a regression: before v9.5.0, `ConfigCatClientOptions.HttpTimeout` applied to the whole HTTP request (receiving the response headers AND the response body). But the aforementioned version changed this inadvertently to only apply the timeout to receiving the headers and ignore however long time downloading the body takes. This PR reverts the original behavior (which is the behavior consistent with other SDKs, by the way).

### Related issues (only if applicable)
https://trello.com/c/bMad80Fm

### How to test? (only if applicable)
n/a

### Security (only if applicable)
n/a

### Requirement checklist (only if applicable)
- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [ ] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
